### PR TITLE
Add patch for Labeled Trunks mod

### DIFF
--- a/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
+++ b/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
@@ -1,0 +1,48 @@
+[
+  {
+    "file": "labeledtrunk:blocktypes/chest-trunk",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "translation": [
+          0.0625,
+          0,
+          -0.5
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "slots": {
+          "Hands": {
+            "animation": "carryon:holdheavy",
+            "walkSpeedModifier": -0.5
+          },
+          "Back": {
+            "walkSpeedModifier": -0.2,
+            "rotation": [
+              0,
+              180,
+              0
+            ],
+            "keepWhenTrue": "carryon:AllowChestTrunksOnBack"
+          }
+        },
+		"multiblockOffset": [0, 0, 1]
+      }
+    },
+    "condition": {
+      "when": "carryon:ChestTrunkEnabled",
+      "isValue": "true"
+    },
+    "dependsOn": [
+      {
+        "modid": "labeledtrunk"
+      }
+    ]  
+  }
+]

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.10.1",
+	"version": "1.10.2",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",


### PR DESCRIPTION
Simple patch for being able to carry the labeled trunks added by the [Labeled Trunks](https://mods.vintagestory.at/labeledtrunk) mod