### PR TITLE
Labeled trunk support

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.10.1</Version>
+		<Version>1.10.2</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.10.1",
+  "carryOnVersion": "1.10.2",
   "vintageStoryVersion": "1.21.0"
 }

--- a/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
+++ b/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
@@ -1,0 +1,48 @@
+[
+  {
+    "file": "labeledtrunk:blocktypes/chest-trunk",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "translation": [
+          0.0625,
+          0,
+          -0.5
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "slots": {
+          "Hands": {
+            "animation": "carryon:holdheavy",
+            "walkSpeedModifier": -0.5
+          },
+          "Back": {
+            "walkSpeedModifier": -0.2,
+            "rotation": [
+              0,
+              180,
+              0
+            ],
+            "keepWhenTrue": "carryon:AllowChestTrunksOnBack"
+          }
+        },
+		"multiblockOffset": [0, 0, 1]
+      }
+    },
+    "condition": {
+      "when": "carryon:ChestTrunkEnabled",
+      "isValue": "true"
+    },
+    "dependsOn": [
+      {
+        "modid": "labeledtrunk"
+      }
+    ]  
+  }
+]

--- a/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
+++ b/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
@@ -32,7 +32,7 @@
             "keepWhenTrue": "carryon:AllowChestTrunksOnBack"
           }
         },
-		"multiblockOffset": [0, 0, 1]
+        "multiblockOffset": [0, 0, 1]
       }
     },
     "condition": {

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.10.1",
+	"version": "1.10.2",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.10.1",
+    Version = "1.10.2",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/Common/CarryHandler.cs
+++ b/src/Common/CarryHandler.cs
@@ -291,9 +291,12 @@ namespace CarryOn.Common
             {
                 return false;
             }
+            
+            // Get origin block if multiblock like a trunk
+            var selection = GetMultiblockOriginSelection(player?.CurrentBlockSelection);
 
             // Can player carry target block
-            bool canCarryTarget = player.CurrentBlockSelection?.Block?.IsCarryable(CarrySlot.Hands) == true;
+            bool canCarryTarget = selection?.Block?.IsCarryable(CarrySlot.Hands) == true;
 
             // Swap back conditions: When carry key is held down and one of the following is true:
             // 1. The carry swap key is pressed
@@ -301,7 +304,7 @@ namespace CarryOn.Common
             // 3. The player has empty hands but has something in back slot and the target block is not carryable
             bool carryKeyHeld = player.Entity.IsCarryKeyHeld();
             bool swapKeyPressed = IsCarrySwapKeyPressed();
-            bool notTargetingBlock = player.CurrentBlockSelection == null;
+            bool notTargetingBlock = selection == null;
             bool canSwapBackFromBackSlot = !canCarryTarget && carriedBack != null && carriedHands == null;
 
             if (carryKeyHeld && (swapKeyPressed || notTargetingBlock || canSwapBackFromBackSlot))
@@ -310,7 +313,7 @@ namespace CarryOn.Common
                 if (carriedHands == null && !notTargetingBlock)
                 {
                     // Don't allow swap back operation if the player is looking at a container with empty hands.
-                    var hasBehavior = player.CurrentBlockSelection?.Block?.HasBehavior<BlockBehaviorContainer>() ?? false;
+                    var hasBehavior = selection?.Block?.HasBehavior<BlockBehaviorContainer>() ?? false;
                     if (hasBehavior)
                     {
                         CompleteInteraction();

--- a/src/Events/TrunkFix.cs
+++ b/src/Events/TrunkFix.cs
@@ -16,7 +16,10 @@ namespace CarryOn.Events
 
         public void OnRestoreEntityBlockData(BlockEntity blockEntity, ITreeAttribute blockEntityData, bool dropped)
         {
-            if (dropped && blockEntity.Block.Shape.Base.Path == "block/wood/trunk/normal")
+            // Fix trunk dropped angle - Sets to a fixed angle for east facing trunk
+            // Updated to support labeled trunks
+            // Should not be required in CarryOn v2
+            if (dropped && blockEntity?.Block?.Shape?.Base?.Path?.StartsWith("block/wood/trunk/") == true)
             {
                 // Workaround fix dropped trunk angle
                 blockEntityData.SetFloat("meshAngle", -90 * GameMath.DEG2RAD);

--- a/src/Events/TrunkFix.cs
+++ b/src/Events/TrunkFix.cs
@@ -19,7 +19,8 @@ namespace CarryOn.Events
             // Fix trunk dropped angle - Sets to a fixed angle for east facing trunk
             // Updated to support labeled trunks
             // Should not be required in CarryOn v2
-            if (dropped && blockEntity?.Block?.Shape?.Base?.Path?.StartsWith("block/wood/trunk/") == true)
+            bool isTrunkBlock = blockEntity?.Block?.Shape?.Base?.Path?.StartsWith("block/wood/trunk/") == true;
+            if (dropped && isTrunkBlock)
             {
                 // Workaround fix dropped trunk angle
                 blockEntityData.SetFloat("meshAngle", -90 * GameMath.DEG2RAD);


### PR DESCRIPTION
### Labeled trunk support

* Added a patch (`labeledtrunks.json`) to support carrying labeled trunks.
* Updated trunk dropped angle fix logic in `TrunkFix.cs` to support labeled trunks and improve compatibility with different trunk types.
* Modified carry interaction logic in `CarryHandler.cs` to use multiblock origin selection for determining carryability and targeting, ensuring correct behavior with multiblock structures like trunks. 
* Bumped mod version to 1.10.2 