### PR TITLE
Remove incorrect Anchor config from server config.

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.12.0</Version>
+		<Version>1.12.1</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.12.0",
+  "carryOnVersion": "1.12.1",
   "vintageStoryVersion": "1.21.0"
 }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.12.0",
+	"version": "1.12.1",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.12.0",
+    Version = "1.12.1",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/Client/Commands.cs
+++ b/src/Client/Commands.cs
@@ -21,11 +21,6 @@ namespace CarryOn.Client
             {
                 api.ChatCommands.Create("carryon")
                     .BeginSubCommand("gui")
-                        //  .carryon gui debug
-                        .BeginSubCommand("debug")
-                            .WithDescription("Toggle CarryOn GUI debug icons (alias)")
-                            .HandleWith(this.CmdCarryOnGuiToggle)
-                        .EndSubCommand()
                             // .carryon gui bg ... (background fill settings)
                             .BeginSubCommand("bg")
                                 .WithDescription("Configure anchor background fill (enable/disable/color/alpha/show)")
@@ -294,12 +289,42 @@ namespace CarryOn.Client
             HudCarried.HandsAnchor = HudCarried.HandsAnchorDefault;
             HudCarried.BackAnchor = HudCarried.BackAnchorDefault;
 
+            // Reset background settings
+            HudCarried.AnchorBackgroundEnabled = true;
+            HudCarried.AnchorBackgroundColor = HudCarried.AnchorBackgroundColorDefault;
+            HudCarried.AnchorBackgroundAlpha = HudCarried.AnchorBackgroundAlphaDefault;
+
+            // Reset border settings
+            HudCarried.AnchorBorderEnabled = true;
+            HudCarried.AnchorBorderColor = HudCarried.AnchorBorderColorDefault;
+            HudCarried.AnchorBorderAlpha = HudCarried.AnchorBorderAlphaDefault;
+
+            // Reset icon highlight settings
+            HudCarried.IconHighlightEnabled = true;
+            HudCarried.IconHighlightColor = HudCarried.IconHighlightColorDefault;
+            HudCarried.IconHighlightAlpha = HudCarried.IconHighlightAlphaDefault;
+
             try
             {
-                if (this.carrySystem?.ClientConfig != null)
+                var cfg = this.carrySystem?.ClientConfig?.Config;
+
+                if (cfg != null)
                 {
-                    this.carrySystem.ClientConfig.Config.HandsAnchor = HudCarried.HandsAnchor.ToString();
-                    this.carrySystem.ClientConfig.Config.BackAnchor = HudCarried.BackAnchor.ToString();
+                    cfg.HandsAnchor = HudCarried.HandsAnchor.ToString();
+                    cfg.BackAnchor = HudCarried.BackAnchor.ToString();
+
+                    cfg.AnchorBackgroundEnabled = HudCarried.AnchorBackgroundEnabled;
+                    cfg.AnchorBackgroundColor = HudCarried.AnchorBackgroundColor;
+                    cfg.AnchorBackgroundAlpha = HudCarried.AnchorBackgroundAlpha;
+
+                    cfg.AnchorBorderEnabled = HudCarried.AnchorBorderEnabled;
+                    cfg.AnchorBorderColor = HudCarried.AnchorBorderColor;
+                    cfg.AnchorBorderAlpha = HudCarried.AnchorBorderAlpha;
+
+                    cfg.IconHighlightEnabled = HudCarried.IconHighlightEnabled;
+                    cfg.IconHighlightColor = HudCarried.IconHighlightColor;
+                    cfg.IconHighlightAlpha = HudCarried.IconHighlightAlpha;
+
                     this.carrySystem.ClientConfig.Save(this.api);
                 }
             }

--- a/src/Client/HudCarried.cs
+++ b/src/Client/HudCarried.cs
@@ -146,8 +146,6 @@ namespace CarryOn.Client
                     this.UpdateCachedPositions(currentGUIScale, currentFrameWidth, currentFrameHeight);
                 }
 
-                // DEBUG: Render colored gears at all positions to visualize placement
-                if (ShowDebugIcons) this.RenderDebugPositions();
 
                 // Decrement highlight timers
                 if (HudCarried.HandsHighlightSecondsRemaining > 0f)
@@ -252,55 +250,22 @@ namespace CarryOn.Client
                     }
                 }
 
-                // Render carried back item (for now, just show in first right position)
-                var carriedBack = player.Entity?.GetCarried(CarrySlot.Back);
-
-                if (carriedBack != null)
-                {
-                    RenderCarriedBlock(rapi, carriedBack, HudCarried.BackAnchor, HudCarried.BackHighlightSecondsRemaining, false);
-                }
 
                 // Render carried hands item (default position L1 -> first left position)
                 var carriedHands = player.Entity?.GetCarried(CarrySlot.Hands);
                 if (carriedHands != null)
                 {
-                    RenderCarriedBlock(rapi, carriedHands, HudCarried.HandsAnchor, HudCarried.HandsHighlightSecondsRemaining, true);
+                    RenderCarriedBlock(rapi, carriedHands, HudCarried.HandsAnchor, HudCarried.HandsHighlightSecondsRemaining);
                 }
 
-                // ... bounding rectangles were moved earlier to render behind highlights/items
+                // Render carried back item (for now, just show in first right position)
+                var carriedBack = player.Entity?.GetCarried(CarrySlot.Back);
 
-            }
-
-            private void RenderDebugPositions()
-            {
-                // Create a simple item for debug visualization
-                var gearItem = this.api.World.GetItem(new AssetLocation("game:gear-rusty"));
-                if (gearItem == null) return;
-
-                var rapi = this.api.Render;
-
-                // Render debug "icons" as colored squares for each position
-                // Left positions (red tinted)
-                for (int i = 0; i < 3; i++)
+                if (carriedBack != null)
                 {
-                    var pos = this.cachedLeftPositions[i];
-                    var dummyItem = new ItemStack(gearItem, 1);
-                    var dummySlot = new DummySlot(dummyItem);
-                    // Render with red tint to distinguish left positions
-                    rapi.RenderItemstackToGui(dummySlot, pos.x, pos.y, 102, this.cachedSlotSize,
-                        ColorUtil.ToRgba(200, 255, 100, 100), true, false, false);
+                    RenderCarriedBlock(rapi, carriedBack, HudCarried.BackAnchor, HudCarried.BackHighlightSecondsRemaining);
                 }
 
-                // Right positions (blue tinted) 
-                for (int i = 0; i < 3; i++)
-                {
-                    var pos = this.cachedRightPositions[i];
-                    var dummyItem = new ItemStack(gearItem, 1);
-                    var dummySlot = new DummySlot(dummyItem);
-                    // Render with blue tint to distinguish right positions
-                    rapi.RenderItemstackToGui(dummySlot, pos.x, pos.y, 102, this.cachedSlotSize,
-                        ColorUtil.ToRgba(200, 100, 100, 255), true, false, false);
-                }
 
             }
 
@@ -577,7 +542,7 @@ namespace CarryOn.Client
             }
 
             // Helper to render a carried block (draw highlight then the item)
-            private void RenderCarriedBlock(IRenderAPI rapi, CarriedBlock carriedBlock, Anchor anchor, float highlightSecondsRemaining, bool isHands)
+            private void RenderCarriedBlock(IRenderAPI rapi, CarriedBlock carriedBlock, Anchor anchor, float highlightSecondsRemaining)
             {
                 var slot = new DummySlot(carriedBlock.ItemStack);
                 var pos = this.GetPositionForAnchor(anchor);
@@ -593,7 +558,7 @@ namespace CarryOn.Client
                 shader.Uniform("noTexture", 0.0F);
 
                 // Render the item. For hands we allow the 'true' flag for the special rendering parameter the code used.
-                rapi.RenderItemstackToGui(slot, pos.x, pos.y, 100, this.cachedSlotSize, -1, isHands, false, true);
+                rapi.RenderItemstackToGui(slot, pos.x, pos.y, 100, this.cachedSlotSize, -1, true, false, true);
             }
 
             private void UpdateCachedPositions(float guiScale, float frameWidth, float frameHeight)

--- a/src/Config/CarryOnConfig.cs
+++ b/src/Config/CarryOnConfig.cs
@@ -65,15 +65,6 @@ namespace CarryOn.Config
         public bool AllowCratesOnBack { get; set; } = false;
 
         public string[] PreventSwapFromBackOnTarget { get; set; } = ["behavior::Container", "behavior::Door", "class::portals.portal"];
-
-        // Anchor background rendering options (client-visible via world config)
-        // Hex color for fill (e.g. "#e4c4a6")
-    public string AnchorBackgroundColor { get; set; } = "#E4C4A6";
-        // Alpha for fill (0.0 - 1.0)
-        public float AnchorBackgroundAlpha { get; set; } = 0.6f;
-        // Whether to draw the fill background (true = enabled)
-        public bool AnchorBackgroundEnabled { get; set; } = true;
-
     }
 
     public class DroppedBlockOptionsConfig
@@ -170,10 +161,6 @@ namespace CarryOn.Config
                 CarryOptions.PreventSwapFromBackOnTarget = previousConfig.CarryOptions.PreventSwapFromBackOnTarget != null
                     ? (string[])previousConfig.CarryOptions.PreventSwapFromBackOnTarget.Clone()
                     : [];
-                // Anchor background options
-                CarryOptions.AnchorBackgroundColor = previousConfig.CarryOptions.AnchorBackgroundColor ?? CarryOptions.AnchorBackgroundColor;
-                CarryOptions.AnchorBackgroundAlpha = previousConfig.CarryOptions.AnchorBackgroundAlpha;
-                CarryOptions.AnchorBackgroundEnabled = previousConfig.CarryOptions.AnchorBackgroundEnabled;
             }
 
             // CarryablesFilters


### PR DESCRIPTION
This pull request updates the mod version to 1.12.1 and removes the GUI debug icon feature, while also improving the robustness of the GUI reset functionality. It also cleans up some configuration code and makes minor refactoring to rendering logic.

**Version Update:**
- Updated the mod version from 1.12.0 to 1.12.1 in all relevant files, including `CarryOn.csproj`, `CarryOn.json`, `modinfo.json`, and assembly attributes. [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-23f506e8f4a47454b2af201b29acf17ae215f39a4208ee073c36b642b9f33f05L2-R2) [[3]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[4]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L24-R24)

**GUI Debug and Rendering Refactor:**
- Removed the GUI debug icon feature and associated command (`carryon gui debug`) and code for rendering debug positions in `HudCarried.cs` and `Commands.cs`. [[1]](diffhunk://#diff-2d8905939b3e0d547dd5292e522e3aaab81745e4d74d7260c76ef306cc94fdf4L24-L28) [[2]](diffhunk://#diff-d4ac669f14fa699c5466b9d1cd5779f22e68a134c047fe4f9c92bcc6ace0102eL149-L150) [[3]](diffhunk://#diff-d4ac669f14fa699c5466b9d1cd5779f22e68a134c047fe4f9c92bcc6ace0102eL255-L303)
- Refactored the `RenderCarriedBlock` method to remove the `isHands` parameter and always use the appropriate rendering flags. [[1]](diffhunk://#diff-d4ac669f14fa699c5466b9d1cd5779f22e68a134c047fe4f9c92bcc6ace0102eL580-R545) [[2]](diffhunk://#diff-d4ac669f14fa699c5466b9d1cd5779f22e68a134c047fe4f9c92bcc6ace0102eL596-R561)

**GUI Reset Improvements:**
- Enhanced the `CmdCarryOnGuiReset` method to reset all anchor background, border, and icon highlight settings to their defaults and save them to the config.

**Configuration Cleanup:**
- Removed anchor background rendering options from the `CarryOptionsConfig` class and its copy constructor, as these are now handled elsewhere. [[1]](diffhunk://#diff-714e0f199cc0917da4f01d825f4471117e0d4e5c969bd3f0259b2b855ae736d7L68-L76) [[2]](diffhunk://#diff-714e0f199cc0917da4f01d825f4471117e0d4e5c969bd3f0259b2b855ae736d7L173-L176)Fix render issue with back slot icon.