### PR TITLE
Add audit logging for block carry

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.12.1</Version>
+		<Version>1.12.2</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.12.1",
+  "carryOnVersion": "1.12.2",
   "vintageStoryVersion": "1.21.0"
 }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.12.1",
+	"version": "1.12.2",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/src/API/Common/CarriedBlock.cs
+++ b/src/API/Common/CarriedBlock.cs
@@ -188,9 +188,13 @@ namespace CarryOn.API.Common
             if (selection == null) throw new ArgumentNullException(nameof(selection));
             if (!world.BlockAccessor.IsValidPos(selection.Position)) return false;
 
+            var logger = world.Logger;
+
             if (entity is EntityPlayer playerEntity && !dropped)
             {
                 failureCode ??= "__ignore__";
+
+                
 
                 var shift = playerEntity.Controls.ShiftKey;
                 var ctrl = playerEntity.Controls.CtrlKey;
@@ -216,7 +220,7 @@ namespace CarryOn.API.Common
                 }
                 catch (NullReferenceException ex)
                 {
-                    world.Logger.Error("Error occured while trying to place a carried block: " + ex.Message);
+                    logger.Error("Error occured while trying to place a carried block: " + ex.Message);
                     // Workaround was for null ref with reed chest - Leaving here in case of other issues
                     world.BlockAccessor.SetBlock(Block.Id, selection.Position, ItemStack);
                 }
@@ -245,6 +249,11 @@ namespace CarryOn.API.Common
             {
                 world.GetCarryEvents()?.TriggerBlockDropped(world, selection.Position, entity, this);
             }
+
+            if (world.Side == EnumAppSide.Server)
+            {
+                logger.Audit($"[{CarrySystem.ModId}] {entity.GetName()} {(dropped ? "dropped" : "placed down")} block {Block.Code.GetName()} at {selection.Position}");
+            }            
 
             return true;
         }

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.AccessControl;
 using CarryOn.API.Event;
 using CarryOn.Common;
 using CarryOn.Config;
@@ -77,6 +78,10 @@ namespace CarryOn.API.Common
 
             carried.Set(entity, slot);
             if (playSound) carried.PlaySound(pos, entity.World, entity as EntityPlayer);
+            if (entity.Api.Side == EnumAppSide.Server)
+            {
+                entity.World.Logger.Audit($"[{CarrySystem.ModId}] {entity.GetName()} picked up block {carried.Block.Code.GetName()} at {pos}");
+            }            
             return true;
         }
 

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.12.1",
+    Version = "1.12.2",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]


### PR DESCRIPTION
This pull request updates the mod version to 1.12.2 and introduces improved server-side auditing for block pickup and placement actions. The changes enhance logging for better traceability and maintain consistency across version references.

**Version updates:**
* Bumped the mod version from 1.12.1 to 1.12.2 in `CarryOn.csproj`, `CarryOn.json`, `resources/modinfo.json`, and `src/CarrySystem.cs` to ensure all metadata reflects the new release. [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-23f506e8f4a47454b2af201b29acf17ae215f39a4208ee073c36b642b9f33f05L2-R2) [[3]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[4]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L24-R24)

**Server-side logging and auditing improvements:**
* Added server-side audit logging for when a block is picked up, recording the entity, block, and position in `CarryableExtensions.cs`.
* Added server-side audit logging for when a block is placed down or dropped, including the entity, block, and position in `CarriedBlock.cs`.
* Refactored logging in `CarriedBlock.cs` to use a local `logger` variable for consistency and clarity. [[1]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dR191-R198) [[2]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dL219-R223)

**Other minor changes:**
* Added an unnecessary `using System.Security.AccessControl;` directive in `CarryableExtensions.cs` (likely unintentional and can be removed).