### PR TITLE
Feature/vessel trap

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.13.0-pre.1</Version>
+		<Version>1.13.0-pre.2</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.13.0-pre.1",
+  "carryOnVersion": "1.13.0-pre.2",
   "vintageStoryVersion": "1.21.0"
 }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.13.0-pre.1",
+	"version": "1.13.0-pre.2",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.13.0-pre.1",
+    Version = "1.13.0-pre.2",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/Common/CarryManager.cs
+++ b/src/Common/CarryManager.cs
@@ -242,7 +242,12 @@ namespace CarryOn.API.Common
                 var droppedBlock = world.GetBlock(assetLocation) ?? carriedBlock.Block;
 
                 world.BlockAccessor.ExchangeBlock(droppedBlock.Id, selection.Position);
-                world.BlockAccessor.SpawnBlockEntity(droppedBlock.EntityClass, selection.Position, carriedBlock.ItemStack);
+
+                // Only spawn block entity if the block has one defined.
+                if (droppedBlock.EntityClass != null)
+                {
+                    world.BlockAccessor.SpawnBlockEntity(droppedBlock.EntityClass, selection.Position, carriedBlock.ItemStack);
+                }
 
                 // Will trigger placement of multiblock sections
                 droppedBlock?.OnBlockPlaced(world, selection.Position, carriedBlock.ItemStack);


### PR DESCRIPTION
Some dropped blocks do not have a block entity. Only spawn a block entity if the dropped block has an entity class defined, preventing null potential errors.