### PR TITLE
Fix crate inventory loss by removing OnBlockPlaced call

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.13.0-pre.2</Version>
+		<Version>1.13.0-pre.3</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.14.0-pre.2</Version>
+		<Version>1.14.0-pre.3</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.13.0-pre.2",
+  "carryOnVersion": "1.13.0-pre.3",
   "vintageStoryVersion": "1.21.0"
 }

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.14.0-pre.2",
-  "vintageStoryVersion": "1.22.0-pre.3"
+  "carryOnVersion": "1.14.0-pre.3",
+  "vintageStoryVersion": "1.22.0-rc.1"
 }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.13.0-pre.2",
+	"version": "1.13.0-pre.3",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,13 +2,13 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.14.0-pre.2",
+	"version": "1.14.0-pre.3",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",
 	"authors": [ "copygirl","NerdScurvy" ],
 
 	"dependencies": {
-		"game": "1.22.0-pre.3"
+		"game": "1.22.0-rc.1"
 	}
 }

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.13.0-pre.2",
+    Version = "1.13.0-pre.3",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,11 +21,11 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.14.0-pre.2",
+    Version = "1.14.0-pre.3",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]
-[assembly: ModDependency("game", "1.22.0-pre.3")]
+[assembly: ModDependency("game", "1.22.0-rc.1")]
 
 namespace CarryOn
 {

--- a/src/Common/CarryManager.cs
+++ b/src/Common/CarryManager.cs
@@ -264,8 +264,9 @@ namespace CarryOn.API.Common
             RestoreBlockEntityData(world, carriedBlock, selection.Position, dropped: dropped);
 
             // Notify the dropped block entity that it has been placed
-            droppedBlockEntity?.OnBlockPlaced(carriedBlock.ItemStack);
-
+            // TODO: Is this required for some block entitues? It can empty crates
+            // droppedBlockEntity?.OnBlockPlaced(carriedBlock.ItemStack);
+            world.BlockAccessor.MarkBlockDirty(selection.Position);
             world.BlockAccessor.TriggerNeighbourBlockUpdate(selection.Position);
 
             RemoveCarried(entity, carriedBlock.Slot);


### PR DESCRIPTION
This pull request updates the Carry On mod to version 1.14.0-pre.3 and bumps its dependency to Vintage Story 1.22.0-rc.1. It also makes a minor code change related to block entity placement logic. The main changes are grouped below:

**Version and Dependency Updates:**

* Updated the mod version to `1.14.0-pre.3` in `CarryOn.csproj`, `CarryOn.json`, `modinfo.json`, and `CarrySystem.cs` to reflect the new release. [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R12) [[3]](diffhunk://#diff-23f506e8f4a47454b2af201b29acf17ae215f39a4208ee073c36b642b9f33f05L2-R3) [[4]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L24-R28)
* Updated the required Vintage Story game version to `1.22.0-rc.1` in `CarryOn.json`, `modinfo.json`, and `CarrySystem.cs` to match the latest release candidate. [[1]](diffhunk://#diff-23f506e8f4a47454b2af201b29acf17ae215f39a4208ee073c36b642b9f33f05L2-R3) [[2]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R12) [[3]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L24-R28)

**Block Placement Logic:**

* Commented out the call to `OnBlockPlaced` for dropped block entities in `CarryManager.cs` (with a note about its effects on crates) and ensured the block is marked dirty after placement. This may affect how certain block entities handle placement events.