### PR TITLE
Feature/1.14 swap guard

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.14.0</Version>
+		<Version>1.14.1</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.14.0",
+  "carryOnVersion": "1.14.1",
   "vintageStoryVersion": "1.22.0"
 }

--- a/resources/assets/carryon/lang/en.json
+++ b/resources/assets/carryon/lang/en.json
@@ -39,5 +39,7 @@
   
   "double-tap-dismount-enabled": "Double Tap Dismount Enabled",
   "double-tap-dismount-disabled": "Double Tap Dismount Disabled",
-  "toggle-double-tap-dismount-hotkey": "CarryOn - Toggle Double Tap Dismount"
+  "toggle-double-tap-dismount-hotkey": "CarryOn - Toggle Double Tap Dismount",
+  "swap-back-error-client": "Unknown error while swapping the carried item to/from your back. Item may be desynced, please relog to fix it. Check client logs for details.",
+  "swap-back-error-server": "Unknown error while swapping the carried item to/from your back. Check server logs for details."
 }

--- a/resources/assets/carryon/lang/en.json
+++ b/resources/assets/carryon/lang/en.json
@@ -40,6 +40,5 @@
   "double-tap-dismount-enabled": "Double Tap Dismount Enabled",
   "double-tap-dismount-disabled": "Double Tap Dismount Disabled",
   "toggle-double-tap-dismount-hotkey": "CarryOn - Toggle Double Tap Dismount",
-  "swap-back-error-client": "Unknown error while swapping the carried item to/from your back. Item may be desynced, please relog to fix it. Check client logs for details.",
-  "swap-back-error-server": "Unknown error while swapping the carried item to/from your back. Check server logs for details."
+  "swap-back-error": "Unknown error while swapping carried item"
 }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.14.0",
+	"version": "1.14.1",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/src/API/Common/CarriedBlock.cs
+++ b/src/API/Common/CarriedBlock.cs
@@ -18,6 +18,9 @@ namespace CarryOn.API.Common
         public static string AttributeId { get; }
             = $"{CarrySystem.ModId}:Carried";
 
+        /// <summary> Revision key under <see cref="AttributeId"/>. </summary>
+        public static string RevisionAttributeKey { get; } = "Rev";
+
         public CarrySlot Slot { get; }
 
         public ItemStack ItemStack { get; }
@@ -90,7 +93,7 @@ namespace CarryOn.API.Common
             if (entity == null) throw new ArgumentNullException(nameof(entity));
 
             entity.WatchedAttributes.Set(stack, AttributeId, slot.ToString(), "Stack");
-            if (markDirty) entity.WatchedAttributes.MarkPathDirty(AttributeId);
+            if (markDirty) TouchCarriedAttributes(entity);
 
             if ((entity.World.Side == EnumAppSide.Server) && (blockEntityData != null))
                 entity.Attributes.Set(blockEntityData, AttributeId, slot.ToString(), "Data");
@@ -142,8 +145,30 @@ namespace CarryOn.API.Common
             }
 
             entity.WatchedAttributes.Remove(AttributeId, slot.ToString());
-            if (markDirty) entity.WatchedAttributes.MarkPathDirty(AttributeId);
+            if (markDirty) TouchCarriedAttributes(entity);
             entity.Attributes.Remove(AttributeId, slot.ToString());
+        }
+
+        /// <summary>
+        /// Increments the carried-state revision and marks the carried root dirty.
+        /// </summary>
+        public static int TouchCarriedAttributes(Entity entity)
+        {
+            if (entity == null) throw new ArgumentNullException(nameof(entity));
+
+            var carriedRoot = entity.WatchedAttributes.TryGet<ITreeAttribute>(AttributeId) ?? new TreeAttribute();
+            var revision = carriedRoot.GetInt(RevisionAttributeKey, 0) + 1;
+            carriedRoot.SetInt(RevisionAttributeKey, revision);
+            entity.WatchedAttributes.Set(carriedRoot, AttributeId);
+            entity.WatchedAttributes.MarkPathDirty(AttributeId);
+            return revision;
+        }
+
+        public static int GetCarriedRevision(Entity entity)
+        {
+            if (entity == null) throw new ArgumentNullException(nameof(entity));
+            var carriedRoot = entity.WatchedAttributes.TryGet<ITreeAttribute>(AttributeId);
+            return carriedRoot?.GetInt(RevisionAttributeKey, 0) ?? 0;
         }
 
         /// <summary> Creates a <see cref="CarriedBlock"/> from the specified world

--- a/src/API/Common/CarriedBlock.cs
+++ b/src/API/Common/CarriedBlock.cs
@@ -63,8 +63,27 @@ namespace CarryOn.API.Common
             return new CarriedBlock(slot, stack, blockEntityData);
         }
 
-        /// <summary> Stores the specified stack and blockEntityData (may be null)
-        ///           as the <see cref="CarriedBlock"/> of the entity in that slot. </summary>
+        /// <summary> 
+        /// Stores the specified stack and blockEntityData (may be null)
+        /// as the <see cref="CarriedBlock"/> of the entity in that slot. 
+        /// </summary>
+        /// <param name="entity"> The entity whose carried block is being set. </param>
+        /// <param name="slot"> The slot in which to set the carried block. </param>
+        /// <param name="stack"> The item stack to set as the carried block. </param>
+        /// <param name="blockEntityData"> The block entity data to set (may be null). </param>
+        /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
+        public static void Set(Entity entity, CarrySlot slot, ItemStack stack, ITreeAttribute blockEntityData)
+            => Set(entity, slot, stack, blockEntityData, true);
+
+        /// <summary>
+        ///  Stores the specified stack and blockEntityData (may be null)
+        ///  as the <see cref="CarriedBlock"/> of the entity in that slot. 
+        /// </summary>
+        /// <param name="entity"> The entity whose carried block is being set. </param>
+        /// <param name="slot"> The slot in which to set the carried block. </param>
+        /// <param name="stack"> The item stack to set as the carried block. </param>
+        /// <param name="blockEntityData"> The block entity data to set (may be null). </param>
+        /// <param name="markDirty"> Whether to mark the entity's watched attributes as dirty after setting. If false, the caller must manually mark dirty for changes to sync. </param>
         /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
         public static void Set(Entity entity, CarrySlot slot, ItemStack stack, ITreeAttribute blockEntityData, bool markDirty = true)
         {

--- a/src/API/Common/CarriedBlock.cs
+++ b/src/API/Common/CarriedBlock.cs
@@ -150,17 +150,26 @@ namespace CarryOn.API.Common
         }
 
         /// <summary>
-        /// Increments the carried-state revision and marks the carried root dirty.
+        /// Increments the carried-state revision and marks the carried root dirty if necessary.
+        /// Client side only returns the current revision, while server side increments and returns the new revision.
         /// </summary>
+        /// <param name="entity">The entity whose carried attributes are being touched.</param>
+        /// <returns> The new revision number. </returns>
         public static int TouchCarriedAttributes(Entity entity)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
 
             var carriedRoot = entity.WatchedAttributes.TryGet<ITreeAttribute>(AttributeId) ?? new TreeAttribute();
-            var revision = carriedRoot.GetInt(RevisionAttributeKey, 0) + 1;
-            carriedRoot.SetInt(RevisionAttributeKey, revision);
-            entity.WatchedAttributes.Set(carriedRoot, AttributeId);
-            entity.WatchedAttributes.MarkPathDirty(AttributeId);
+            var revision = carriedRoot.GetInt(RevisionAttributeKey, 0);
+
+            // Only server has authority to update the revision 
+            if (entity.World.Side == EnumAppSide.Server)
+            {
+                carriedRoot.SetInt(RevisionAttributeKey, ++revision);
+                entity.WatchedAttributes.Set(carriedRoot, AttributeId);
+                entity.WatchedAttributes.MarkPathDirty(AttributeId);
+            }
+
             return revision;
         }
 

--- a/src/API/Common/CarriedBlock.cs
+++ b/src/API/Common/CarriedBlock.cs
@@ -66,12 +66,12 @@ namespace CarryOn.API.Common
         /// <summary> Stores the specified stack and blockEntityData (may be null)
         ///           as the <see cref="CarriedBlock"/> of the entity in that slot. </summary>
         /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
-        public static void Set(Entity entity, CarrySlot slot, ItemStack stack, ITreeAttribute blockEntityData)
+        public static void Set(Entity entity, CarrySlot slot, ItemStack stack, ITreeAttribute blockEntityData, bool markDirty = true)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
 
             entity.WatchedAttributes.Set(stack, AttributeId, slot.ToString(), "Stack");
-            ((SyncedTreeAttribute)entity.WatchedAttributes).MarkPathDirty(AttributeId);
+            if (markDirty) entity.WatchedAttributes.MarkPathDirty(AttributeId);
 
             if ((entity.World.Side == EnumAppSide.Server) && (blockEntityData != null))
                 entity.Attributes.Set(blockEntityData, AttributeId, slot.ToString(), "Data");
@@ -100,13 +100,13 @@ namespace CarryOn.API.Common
         /// <summary> Stores this <see cref="CarriedBlock"/> as the
         ///           specified entity's carried block in that slot. </summary>
         /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
-        public void Set(Entity entity, CarrySlot slot)
-            => Set(entity, slot, ItemStack, BlockEntityData);
+        public void Set(Entity entity, CarrySlot slot, bool markDirty = true)
+            => Set(entity, slot, ItemStack, BlockEntityData, markDirty);
 
         /// <summary> Removes the <see cref="CarriedBlock"/>
         ///           carried by the specified entity in that slot. </summary>
         /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
-        public static void Remove(Entity entity, CarrySlot slot)
+        public static void Remove(Entity entity, CarrySlot slot, bool markDirty = true)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
 
@@ -123,7 +123,7 @@ namespace CarryOn.API.Common
             }
 
             entity.WatchedAttributes.Remove(AttributeId, slot.ToString());
-            ((SyncedTreeAttribute)entity.WatchedAttributes).MarkPathDirty(AttributeId);
+            if (markDirty) entity.WatchedAttributes.MarkPathDirty(AttributeId);
             entity.Attributes.Remove(AttributeId, slot.ToString());
         }
 

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using CarryOn.API.Event;
 using CarryOn.Common;
+using CarryOn.Common.Network;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
@@ -181,17 +182,23 @@ namespace CarryOn.API.Common
             {
 
                 entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. {ex}");
+                var message = Lang.Get(CarrySystem.ModId + ":swap-back-error");
 
                 if (isServer)
                 {
                     var serverPlayer = (entity as EntityPlayer)?.Player as IServerPlayer;
-                    serverPlayer?.SendIngameError("carryon", "swap-back-error", Lang.Get(CarrySystem.ModId + ":swap-back-error-server"));
+                    serverPlayer?.SendIngameError("carryon", "swap-back-error", message);
                 }
                 else
                 {
-                    // Client side error - player may need to relog to fix desync
+                    // Client side error - try to request a resync
                     var capi = entity.Api as ICoreClientAPI;
-                    capi?.TriggerIngameError("carryon", "swap-back-error", Lang.Get(CarrySystem.ModId + ":swap-back-error-client"));
+                    capi?.TriggerIngameError("carryon", "swap-back-error", message);
+                    // Request a resync of carryon watched attributes in case of client desync
+                    var localRevision = CarriedBlock.GetCarriedRevision(entity);
+                    var manager = CarrySystem.GetCarryManager(capi);
+                    manager.CarrySystem.ClientChannel.SendPacket(new CarryResyncRequestMessage(localRevision));
+
                     return false;
 
                 }

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -8,6 +8,7 @@ using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Config;
+using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
 using Vintagestory.GameContent;
@@ -147,67 +148,83 @@ namespace CarryOn.API.Common
 
             var carriedFirst = CarriedBlock.Get(entity, first);
             var carriedSecond = CarriedBlock.Get(entity, second);
-            if ((carriedFirst == null) && (carriedSecond == null)) return false;
+            bool success;
+
+            if ((carriedFirst == null) && (carriedSecond == null))
+            {
+                entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+                return false;
+            }
 
             // Check if the carried blocks can be swapped in their new slots
             bool canSetFirst = carriedFirst == null || carriedFirst.Block.GetBehavior<BlockBehaviorCarryable>()?.Slots?[second] != null;
             bool canSetSecond = carriedSecond == null || carriedSecond.Block.GetBehavior<BlockBehaviorCarryable>()?.Slots?[first] != null;
 
             if (!canSetFirst || !canSetSecond)
+            {
+                entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
                 return false;
+            }
 
-            CarriedBlock.Remove(entity, first);
-            CarriedBlock.Remove(entity, second);
+            CarriedBlock.Remove(entity, first, markDirty: false);
+            CarriedBlock.Remove(entity, second, markDirty: false);
 
             try
             {
-                carriedFirst?.Set(entity, second);
-                carriedSecond?.Set(entity, first);
+                carriedFirst?.Set(entity, second, markDirty: false);
+                carriedSecond?.Set(entity, first, markDirty: false);
+                success = true;
             }
             catch (Exception ex)
             {
-                if (entity.Api is ICoreClientAPI capi)
-                {
-                    entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. {ex}");
-                    capi.TriggerIngameError("carryon", "cannot-swap-back", Lang.Get(CarrySystem.ModId + ":cannot-swap-back"));
-                    return false;
-                }
-                if(entity is EntityPlayer player && player.Player is IServerPlayer serverPlayer)
-                {
-                    serverPlayer.SendIngameError("carryon", "cannot-swap-back", Lang.Get(CarrySystem.ModId + ":cannot-swap-back"));
-                }
-                entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. Rolling back changes. {ex}");
+                bool isServer = entity.Api.Side == EnumAppSide.Server;
 
-                // Rollback: restore original state if anything fails
+                entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. {ex}");
+
+                var message = Lang.Get(CarrySystem.ModId + ":cannot-swap-back");
+
+                if (isServer)
+                {
+                    var serverPlayer = ((EntityPlayer)entity).Player as IServerPlayer;
+                    serverPlayer?.SendIngameError("carryon", "cannot-swap-back", message);
+                }
+                else
+                {
+                    var capi = (ICoreClientAPI)entity.Api;
+                    capi.TriggerIngameError("carryon", "cannot-swap-back", message);
+                }
+
+                // Rollback: restore original state if anything fails (client and server)
                 try
                 {
-                    carriedFirst?.Set(entity, first);
-                    carriedSecond?.Set(entity, second);
+                    carriedFirst?.Set(entity, first, markDirty: false);
+                    carriedSecond?.Set(entity, second, markDirty: false);
                 }
                 catch (Exception rollbackEx)
                 {
                     entity.World.Logger.Error($"[{CarrySystem.ModId}] Rollback also failed for entity {entity.GetName()}. Attempting to drop carried blocks: {rollbackEx}");
-                    CarriedBlock.Remove(entity, first);
-                    CarriedBlock.Remove(entity, second);
+                    CarriedBlock.Remove(entity, first, markDirty: false);
+                    CarriedBlock.Remove(entity, second, markDirty: false);
 
-                    // Last resort: drop the blocks if we can't restore them to their original state
-                    var manager = CarrySystem.GetCarryManager(entity.Api);
-
-                    if (carriedFirst != null)
+                    // Only server drops blocks as last resort
+                    if (isServer)
                     {
-                        manager?.DropCarriedBlock(entity, carriedFirst);
+                        var manager = CarrySystem.GetCarryManager(entity.Api);
+                        if (carriedFirst != null)
+                        {
+                            manager?.DropCarriedBlock(entity, carriedFirst);
+                        }
+                        if (carriedSecond != null)
+                        {
+                            manager?.DropCarriedBlock(entity, carriedSecond);
+                        }
                     }
-                    if (carriedSecond != null)
-                    {
-                        manager?.DropCarriedBlock(entity, carriedSecond);
-                    }
-
-                } 
-
-                return false;
+                }
+                success = false;
             }
 
-            return true;
+            entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+            return success;
         }
 
         public static bool IsCarryKeyHeld(this Entity entity)

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -2,14 +2,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.AccessControl;
 using CarryOn.API.Event;
 using CarryOn.Common;
-using CarryOn.Config;
-using CarryOn.Utility;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
-using Vintagestory.API.Datastructures;
+using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
 using Vintagestory.GameContent;
@@ -168,11 +166,44 @@ namespace CarryOn.API.Common
             }
             catch (Exception ex)
             {
-                // Rollback: restore original state if anything fails
-                carriedFirst?.Set(entity, first);
-                carriedSecond?.Set(entity, second);
-
+                if (entity.Api is ICoreClientAPI capi)
+                {
+                    entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. {ex}");
+                    capi.TriggerIngameError("carryon", "cannot-swap-back", Lang.Get(CarrySystem.ModId + ":cannot-swap-back"));
+                    return false;
+                }
+                if(entity is EntityPlayer player && player.Player is IServerPlayer serverPlayer)
+                {
+                    serverPlayer.SendIngameError("carryon", "cannot-swap-back", Lang.Get(CarrySystem.ModId + ":cannot-swap-back"));
+                }
                 entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. Rolling back changes. {ex}");
+
+                // Rollback: restore original state if anything fails
+                try
+                {
+                    carriedFirst?.Set(entity, first);
+                    carriedSecond?.Set(entity, second);
+                }
+                catch (Exception rollbackEx)
+                {
+                    entity.World.Logger.Error($"[{CarrySystem.ModId}] Rollback also failed for entity {entity.GetName()}. Attempting to drop carried blocks: {rollbackEx}");
+                    CarriedBlock.Remove(entity, first);
+                    CarriedBlock.Remove(entity, second);
+
+                    // Last resort: drop the blocks if we can't restore them to their original state
+                    var manager = CarrySystem.GetCarryManager(entity.Api);
+
+                    if (carriedFirst != null)
+                    {
+                        manager?.DropCarriedBlock(entity, carriedFirst);
+                    }
+                    if (carriedSecond != null)
+                    {
+                        manager?.DropCarriedBlock(entity, carriedSecond);
+                    }
+
+                } 
+
                 return false;
             }
 

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -154,7 +154,7 @@ namespace CarryOn.API.Common
 
             if ((carriedFirst == null) && (carriedSecond == null))
             {
-                entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+                if (isServer) CarriedBlock.TouchCarriedAttributes(entity);
                 return false;
             }
 
@@ -164,7 +164,7 @@ namespace CarryOn.API.Common
 
             if (!canSetFirst || !canSetSecond)
             {
-                entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+                if (isServer) CarriedBlock.TouchCarriedAttributes(entity);
                 return false;
             }
 
@@ -225,7 +225,7 @@ namespace CarryOn.API.Common
                 success = false;
             }
 
-            if (isServer) entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+            if (isServer) CarriedBlock.TouchCarriedAttributes(entity);
             return success;
         }
 

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -196,8 +196,8 @@ namespace CarryOn.API.Common
                     capi?.TriggerIngameError("carryon", "swap-back-error", message);
                     // Request a resync of carryon watched attributes in case of client desync
                     var localRevision = CarriedBlock.GetCarriedRevision(entity);
-                    var manager = CarrySystem.GetCarryManager(capi);
-                    manager.CarrySystem.ClientChannel.SendPacket(new CarryResyncRequestMessage(localRevision));
+                    CarrySystem.GetCarryManager(capi)?.CarrySystem.ClientChannel
+                        .SendPacket(new CarryResyncRequestMessage(localRevision));
 
                     return false;
 

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -81,7 +81,7 @@ namespace CarryOn.API.Common
             {
                 var entityName = entity?.GetName() ?? "Unknown Entity";
                 entity.World.Logger.Audit($"[{CarrySystem.ModId}] {entityName} picked up block {carried.Block.Code.GetName()} at {pos}");
-            }            
+            }
             return true;
         }
 
@@ -135,7 +135,7 @@ namespace CarryOn.API.Common
             var carryManager = CarrySystem.GetCarryManager(api);
             carryManager?.DropCarried(entity, Enum.GetValues(typeof(CarrySlot)).Cast<CarrySlot>(), hSize);
         }
-                     
+
 
         /// <summary>
         ///   Attempts to swap the <see cref="CarriedBlock"/>s currently carried in the
@@ -145,6 +145,8 @@ namespace CarryOn.API.Common
         public static bool Swap(this Entity entity, CarrySlot first, CarrySlot second)
         {
             if (first == second) throw new ArgumentException("Slots can't be the same");
+
+            bool isServer = entity.Api.Side == EnumAppSide.Server;
 
             var carriedFirst = CarriedBlock.Get(entity, first);
             var carriedSecond = CarriedBlock.Get(entity, second);
@@ -177,21 +179,21 @@ namespace CarryOn.API.Common
             }
             catch (Exception ex)
             {
-                bool isServer = entity.Api.Side == EnumAppSide.Server;
 
                 entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. {ex}");
-
-                var message = Lang.Get(CarrySystem.ModId + ":cannot-swap-back");
 
                 if (isServer)
                 {
                     var serverPlayer = (entity as EntityPlayer)?.Player as IServerPlayer;
-                    serverPlayer?.SendIngameError("carryon", "cannot-swap-back", message);
+                    serverPlayer?.SendIngameError("carryon", "swap-back-error", Lang.Get(CarrySystem.ModId + ":swap-back-error-server"));
                 }
                 else
                 {
+                    // Client side error - player may need to relog to fix desync
                     var capi = entity.Api as ICoreClientAPI;
-                    capi?.TriggerIngameError("carryon", "cannot-swap-back", message);
+                    capi?.TriggerIngameError("carryon", "swap-back-error", Lang.Get(CarrySystem.ModId + ":swap-back-error-client"));
+                    return false;
+
                 }
 
                 // Rollback: restore original state if anything fails (client and server)
@@ -223,7 +225,7 @@ namespace CarryOn.API.Common
                 success = false;
             }
 
-            entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+            if (isServer) entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
             return success;
         }
 

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -151,11 +151,30 @@ namespace CarryOn.API.Common
             var carriedSecond = CarriedBlock.Get(entity, second);
             if ((carriedFirst == null) && (carriedSecond == null)) return false;
 
+            // Check if the carried blocks can be swapped in their new slots
+            bool canSetFirst = carriedFirst == null || carriedFirst.Block.GetBehavior<BlockBehaviorCarryable>()?.Slots?[second] != null;
+            bool canSetSecond = carriedSecond == null || carriedSecond.Block.GetBehavior<BlockBehaviorCarryable>()?.Slots?[first] != null;
+
+            if (!canSetFirst || !canSetSecond)
+                return false;
+
             CarriedBlock.Remove(entity, first);
             CarriedBlock.Remove(entity, second);
 
-            carriedFirst?.Set(entity, second);
-            carriedSecond?.Set(entity, first);
+            try
+            {
+                carriedFirst?.Set(entity, second);
+                carriedSecond?.Set(entity, first);
+            }
+            catch (Exception ex)
+            {
+                // Rollback: restore original state if anything fails
+                carriedFirst?.Set(entity, first);
+                carriedSecond?.Set(entity, second);
+
+                entity.World.Logger.Error($"[{CarrySystem.ModId}] Failed to swap carried blocks for entity {entity.GetName()}. Rolling back changes. {ex}");
+                return false;
+            }
 
             return true;
         }

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -185,13 +185,13 @@ namespace CarryOn.API.Common
 
                 if (isServer)
                 {
-                    var serverPlayer = ((EntityPlayer)entity).Player as IServerPlayer;
+                    var serverPlayer = (entity as EntityPlayer)?.Player as IServerPlayer;
                     serverPlayer?.SendIngameError("carryon", "cannot-swap-back", message);
                 }
                 else
                 {
-                    var capi = (ICoreClientAPI)entity.Api;
-                    capi.TriggerIngameError("carryon", "cannot-swap-back", message);
+                    var capi = entity.Api as ICoreClientAPI;
+                    capi?.TriggerIngameError("carryon", "cannot-swap-back", message);
                 }
 
                 // Rollback: restore original state if anything fails (client and server)

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -152,7 +152,8 @@ namespace CarryOn
                 .RegisterMessageType<DetachMessage>()
                 .RegisterMessageType<QuickDropMessage>()
                 .RegisterMessageType<DismountMessage>()
-                .RegisterMessageType<PlayerAttributeUpdateMessage>();
+                .RegisterMessageType<PlayerAttributeUpdateMessage>()
+                .RegisterMessageType<CarryRevisionMessage>();
 
             EntityCarryRenderer = new EntityCarryRenderer(api);
             HudOverlayRenderer = new HudOverlayRenderer(api);
@@ -236,7 +237,8 @@ namespace CarryOn
                 .RegisterMessageType<DetachMessage>()
                 .RegisterMessageType<QuickDropMessage>()
                 .RegisterMessageType<DismountMessage>()
-                .RegisterMessageType<PlayerAttributeUpdateMessage>();
+                .RegisterMessageType<PlayerAttributeUpdateMessage>()
+                .RegisterMessageType<CarryRevisionMessage>();
 
             DeathHandler = new DeathHandler(api);
             CarryHandler.InitServer();

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -153,7 +153,8 @@ namespace CarryOn
                 .RegisterMessageType<QuickDropMessage>()
                 .RegisterMessageType<DismountMessage>()
                 .RegisterMessageType<PlayerAttributeUpdateMessage>()
-                .RegisterMessageType<CarryRevisionMessage>();
+                .RegisterMessageType<CarryRevisionMessage>()
+                .RegisterMessageType<CarryResyncRequestMessage>();
 
             EntityCarryRenderer = new EntityCarryRenderer(api);
             HudOverlayRenderer = new HudOverlayRenderer(api);
@@ -238,7 +239,8 @@ namespace CarryOn
                 .RegisterMessageType<QuickDropMessage>()
                 .RegisterMessageType<DismountMessage>()
                 .RegisterMessageType<PlayerAttributeUpdateMessage>()
-                .RegisterMessageType<CarryRevisionMessage>();
+                .RegisterMessageType<CarryRevisionMessage>()
+                .RegisterMessageType<CarryResyncRequestMessage>();
 
             DeathHandler = new DeathHandler(api);
             CarryHandler.InitServer();

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.14.0",
+    Version = "1.14.1",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/Common/CarryHandler.cs
+++ b/src/Common/CarryHandler.cs
@@ -42,6 +42,15 @@ namespace CarryOn.Common
         private Type[] preventSwapFromBackOnBehaviors = [];
         private string[] preventSwapFromBackOnClasses = [];
 
+        /// <summary> Tracks the last resync grant time (in server elapsed ms) per player UID
+        ///           to prevent clients from flooding the server with resync requests. </summary>
+        private readonly Dictionary<string, long> _resyncCooldowns = new();
+        private const long ResyncCooldownMs = 2000;
+
+        /// <summary> How long (ms) the client waits before sending a resync request, giving
+        ///           the normal watched-attribute replication a chance to arrive first. </summary>
+        private const int ResyncRequestDelayMs = 500;
+
         public void InitClient()
         {
             var cApi = CarrySystem.ClientAPI;
@@ -129,13 +138,27 @@ namespace CarryOn.Common
                 .SetMessageHandler<DetachMessage>(OnDetachMessage)
                 .SetMessageHandler<QuickDropMessage>(OnQuickDropMessage)
                 .SetMessageHandler<DismountMessage>(OnDismountMessage)
-                .SetMessageHandler<PlayerAttributeUpdateMessage>(OnPlayerAttributeUpdateMessage);
+                .SetMessageHandler<PlayerAttributeUpdateMessage>(OnPlayerAttributeUpdateMessage)
+                .SetMessageHandler<CarryResyncRequestMessage>(OnCarryResyncRequestMessage);
 
             CarrySystem.ServerAPI.Event.OnEntitySpawn += OnServerEntitySpawn;
             CarrySystem.ServerAPI.Event.PlayerNowPlaying += OnServerPlayerNowPlaying;
 
             CarrySystem.ServerAPI.Event.BeforeActiveSlotChanged +=
                 (player, _) => OnBeforeActiveSlotChanged(player.Entity);
+        }
+
+        private void OnCarryResyncRequestMessage(IServerPlayer player, CarryResyncRequestMessage message)
+        {
+            var now = player.Entity.World.ElapsedMilliseconds;
+            if (_resyncCooldowns.TryGetValue(player.PlayerUID, out var last) && now - last < ResyncCooldownMs)
+                return;
+
+            _resyncCooldowns[player.PlayerUID] = now;
+            CarrySystem.Api.Logger.Debug(
+                $"[{CarrySystem.ModId}] Carry resync requested by {player.PlayerName} " +
+                $"(client rev={message.LocalRevision}, server rev={CarriedBlock.GetCarriedRevision(player.Entity)})");
+            player.Entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
         }
 
         private void OnDismountMessage(IServerPlayer player, DismountMessage message)
@@ -754,6 +777,16 @@ namespace CarryOn.Common
                 // Local carry state is behind the server's — cancel any in-progress
                 // carry interaction. Authoritative state will arrive via watched attributes.
                 CancelInteraction(resetTimeHeld: true);
+
+                // Schedule a delayed re-check so normal watched-attribute replication can arrive first.
+                CarrySystem.ClientAPI.Event.RegisterCallback(
+                    _ =>
+                    {
+                        var delayedLocalRevision = CarriedBlock.GetCarriedRevision(player.Entity);
+                        if (delayedLocalRevision < message.Revision)
+                            CarrySystem.ClientChannel.SendPacket(new CarryResyncRequestMessage(delayedLocalRevision));
+                    },
+                    ResyncRequestDelayMs);
             }
         }
 

--- a/src/Common/CarryHandler.cs
+++ b/src/Common/CarryHandler.cs
@@ -44,8 +44,11 @@ namespace CarryOn.Common
 
         /// <summary> Tracks the last resync grant time (in server elapsed ms) per player UID
         ///           to prevent clients from flooding the server with resync requests. </summary>
-        private readonly Dictionary<string, long> _resyncCooldowns = new();
+        private readonly Dictionary<string, long> resyncCooldowns = new();
         private const long ResyncCooldownMs = 2000;
+        private const long ResyncCooldownPruneIntervalMs = 60_000;
+        private const long ResyncCooldownMaxAgeMs = 10 * 60_000;
+        private long nextResyncCooldownPruneAtMs;
 
         /// <summary> How long (ms) the client waits before sending a resync request, giving
         ///           the normal watched-attribute replication a chance to arrive first. </summary>
@@ -151,14 +154,29 @@ namespace CarryOn.Common
         private void OnCarryResyncRequestMessage(IServerPlayer player, CarryResyncRequestMessage message)
         {
             var now = player.Entity.World.ElapsedMilliseconds;
-            if (_resyncCooldowns.TryGetValue(player.PlayerUID, out var last) && now - last < ResyncCooldownMs)
+            PruneResyncCooldowns(now);
+
+            if (this.resyncCooldowns.TryGetValue(player.PlayerUID, out var last) && now - last < ResyncCooldownMs)
                 return;
 
-            _resyncCooldowns[player.PlayerUID] = now;
+            this.resyncCooldowns[player.PlayerUID] = now;
             CarrySystem.Api.Logger.Debug(
                 $"[{CarrySystem.ModId}] Carry resync requested by {player.PlayerName} " +
                 $"(client rev={message.LocalRevision}, server rev={CarriedBlock.GetCarriedRevision(player.Entity)})");
             player.Entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+        }
+
+        private void PruneResyncCooldowns(long now)
+        {
+            if (now < this.nextResyncCooldownPruneAtMs) return;
+
+            this.nextResyncCooldownPruneAtMs = now + ResyncCooldownPruneIntervalMs;
+            if (this.resyncCooldowns.Count == 0) return;
+
+            foreach (var uid in this.resyncCooldowns.Where(entry => now - entry.Value > ResyncCooldownMaxAgeMs).Select(entry => entry.Key).ToList())
+            {
+                this.resyncCooldowns.Remove(uid);
+            }
         }
 
         private void OnDismountMessage(IServerPlayer player, DismountMessage message)

--- a/src/Common/CarryHandler.cs
+++ b/src/Common/CarryHandler.cs
@@ -60,6 +60,7 @@ namespace CarryOn.Common
             input.SetHotKeyHandler(ToggleDoubleTapDismountKeyCode, TriggerToggleDoubleTapDismountKeyPressed);
 
             CarrySystem.ClientChannel.SetMessageHandler<LockSlotsMessage>(OnLockSlotsMessage);
+            CarrySystem.ClientChannel.SetMessageHandler<CarryRevisionMessage>(OnCarryRevisionMessage);
 
             cApi.Input.InWorldAction += OnEntityAction;
             cApi.Event.RegisterGameTickListener(OnGameTick, 0);
@@ -744,6 +745,18 @@ namespace CarryOn.Common
                 : EnumHandling.PassThrough;
         }
 
+        public void OnCarryRevisionMessage(CarryRevisionMessage message)
+        {
+            var player = CarrySystem.ClientAPI.World.Player;
+            var localRevision = CarriedBlock.GetCarriedRevision(player.Entity);
+            if (localRevision < message.Revision)
+            {
+                // Local carry state is behind the server's — cancel any in-progress
+                // carry interaction. Authoritative state will arrive via watched attributes.
+                CancelInteraction(resetTimeHeld: true);
+            }
+        }
+
         public void OnLockSlotsMessage(LockSlotsMessage message)
         {
             var player = CarrySystem.ClientAPI.World.Player;
@@ -767,6 +780,21 @@ namespace CarryOn.Common
             if ((player == null) || (player.World.PlayerByUid(player.PlayerUID) is not IServerPlayer serverPlayer)) return;
             var system = player.World.Api.ModLoader.GetModSystem<CarrySystem>();
             system.CarryHandler.SendLockSlotsMessage(serverPlayer);
+        }
+
+        /// <summary> Sends the current carried revision to the specified player so they
+        ///           can detect if their local carry state is stale. </summary>
+        public void SendCarryRevision(IServerPlayer player)
+        {
+            var revision = CarriedBlock.GetCarriedRevision(player.Entity);
+            CarrySystem.ServerChannel.SendPacket(new CarryRevisionMessage(revision), player);
+        }
+
+        public static void SendCarryRevision(EntityPlayer player)
+        {
+            if ((player == null) || (player.World.PlayerByUid(player.PlayerUID) is not IServerPlayer serverPlayer)) return;
+            var system = player.World.Api.ModLoader.GetModSystem<CarrySystem>();
+            system.CarryHandler.SendCarryRevision(serverPlayer);
         }
 
         private void OnInteractMessage(IServerPlayer player, InteractMessage message)
@@ -801,6 +829,10 @@ namespace CarryOn.Common
             {
                 InvalidCarry(player, message.Position);
             }
+            else
+            {
+                SendCarryRevision(player);
+            }
         }
 
         public void OnPlaceDownMessage(IServerPlayer player, PlaceDownMessage message)
@@ -826,9 +858,11 @@ namespace CarryOn.Common
             }
             // If succeeded, but by chance the client's projected placement isn't
             // the same as the server's, re-sync the block at the client's position.
-            else if (placedAt != message.PlacedAt)
+            else
             {
-                player.Entity.World.BlockAccessor.MarkBlockDirty(message.PlacedAt);
+                if (placedAt != message.PlacedAt)
+                    player.Entity.World.BlockAccessor.MarkBlockDirty(message.PlacedAt);
+                SendCarryRevision(player);
             }
         }
 
@@ -842,7 +876,8 @@ namespace CarryOn.Common
                 if (player.Entity.Swap(message.First, message.Second))
                 {
                     CarrySystem.Api.World.PlaySoundAt(new AssetLocation("sounds/player/throw"), player.Entity);
-                    player.Entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+                    CarriedBlock.TouchCarriedAttributes(player.Entity);
+                    SendCarryRevision(player);
                 }
             }
         }
@@ -1131,6 +1166,7 @@ namespace CarryOn.Common
                 targetEntity.MarkShapeModified();
                 targetEntity.World.BlockAccessor.GetChunkAtBlockPos(targetEntity.Pos.AsBlockPos).MarkModified();
                 CarrySystem.Api.World.Logger.Audit($"[{CarrySystem.ModId}] Player {player?.PlayerName} detached block {block.Code} from entity {targetEntity.EntityId} {targetEntity.GetName()} slot {message.SlotIndex} at position {targetEntity.Pos.AsBlockPos}");
+                SendCarryRevision(player);
             }
 
         }
@@ -1210,9 +1246,11 @@ namespace CarryOn.Common
         private void InvalidCarry(IServerPlayer player, BlockPos pos)
         {
             player.Entity.World.BlockAccessor.MarkBlockDirty(pos);
-            player.Entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+            CarriedBlock.TouchCarriedAttributes(player.Entity);
             player.Entity.WatchedAttributes.MarkPathDirty("stats/walkspeed");
             SendLockSlotsMessage(player);
+            // Tell the client to re-check the carried block's validity
+            SendCarryRevision(player);
         }
 
         /// <summary> Returns the position that the specified block would

--- a/src/Common/CarryHandler.cs
+++ b/src/Common/CarryHandler.cs
@@ -774,17 +774,17 @@ namespace CarryOn.Common
             var localRevision = CarriedBlock.GetCarriedRevision(player.Entity);
             if (localRevision < message.Revision)
             {
-                // Local carry state is behind the server's — cancel any in-progress
-                // carry interaction. Authoritative state will arrive via watched attributes.
-                CancelInteraction(resetTimeHeld: true);
-
                 // Schedule a delayed re-check so normal watched-attribute replication can arrive first.
                 CarrySystem.ClientAPI.Event.RegisterCallback(
                     _ =>
                     {
                         var delayedLocalRevision = CarriedBlock.GetCarriedRevision(player.Entity);
                         if (delayedLocalRevision < message.Revision)
+                        {
+                            // Client is still out of sync, likely due to a missed packet or similar. Cancel the current interaction if any, and request a full re-sync.
+                            CancelInteraction(resetTimeHeld: true);
                             CarrySystem.ClientChannel.SendPacket(new CarryResyncRequestMessage(delayedLocalRevision));
+                        }
                     },
                     ResyncRequestDelayMs);
             }
@@ -909,7 +909,6 @@ namespace CarryOn.Common
                 if (player.Entity.Swap(message.First, message.Second))
                 {
                     CarrySystem.Api.World.PlaySoundAt(new AssetLocation("sounds/player/throw"), player.Entity);
-                    CarriedBlock.TouchCarriedAttributes(player.Entity);
                     SendCarryRevision(player);
                 }
             }

--- a/src/Common/CarryManager.cs
+++ b/src/Common/CarryManager.cs
@@ -306,20 +306,35 @@ namespace CarryOn.API.Common
 
             foreach (var carriedBlock in remaining)
             {
-                var blockSelection = blockPlacer.FindBlockPlacement(carriedBlock.Block, centerBlock, range);
-
-                if (blockSelection == null)
-                {
-                    DropBlockAsItem(carriedBlock, centerBlock, player, entity);
-                    continue;
-                }
-
-                if (TryPlaceDown(entity, carriedBlock, blockSelection, dropped: true))
-                {
-                    continue;
-                }
-                DropBlockAsItem(carriedBlock, centerBlock, player, entity);
+                DropCarriedBlock(entity, carriedBlock, range, blockPlacer);
             }
+        }
+
+        public void DropCarriedBlock(Entity entity, CarriedBlock carriedBlock, int range = 4, BlockPlacer blockPlacer = null)
+        {
+            if (carriedBlock == null) return;
+
+            ArgumentNullException.ThrowIfNull(entity);
+            
+            if (range < 0) throw new ArgumentOutOfRangeException(nameof(range));
+
+            IServerPlayer player = (entity is EntityPlayer entityPlayer) ? (IServerPlayer)entityPlayer.Player : null;
+
+            BlockPos centerBlock = entity.Pos.AsBlockPos.UpCopy();
+            blockPlacer ??= new BlockPlacer(entity.Api);
+
+            var blockSelection = blockPlacer.FindBlockPlacement(carriedBlock.Block, centerBlock, range);
+            if (blockSelection == null)
+            {
+                DropBlockAsItem(carriedBlock, centerBlock, player, entity);
+                return;
+            }          
+
+            if (TryPlaceDown(entity, carriedBlock, blockSelection, dropped: true))
+            {
+                return;
+            }
+            DropBlockAsItem(carriedBlock, centerBlock, player, entity);
         }
 
         /// <summary>

--- a/src/Common/CarryManager.cs
+++ b/src/Common/CarryManager.cs
@@ -291,6 +291,7 @@ namespace CarryOn.API.Common
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (range < 0) throw new ArgumentOutOfRangeException(nameof(range));
 
+            if (entity.World.Side != EnumAppSide.Server) return;
 
             IServerPlayer player = (entity is EntityPlayer entityPlayer) ? (IServerPlayer)entityPlayer.Player : null;
 
@@ -315,7 +316,9 @@ namespace CarryOn.API.Common
             if (carriedBlock == null) return;
 
             ArgumentNullException.ThrowIfNull(entity);
-            
+
+            if (entity.World.Side != EnumAppSide.Server) return;
+
             if (range < 0) throw new ArgumentOutOfRangeException(nameof(range));
 
             IServerPlayer player = (entity is EntityPlayer entityPlayer) ? (IServerPlayer)entityPlayer.Player : null;

--- a/src/Common/CarryManager.cs
+++ b/src/Common/CarryManager.cs
@@ -293,8 +293,6 @@ namespace CarryOn.API.Common
 
             if (entity.World.Side != EnumAppSide.Server) return;
 
-            IServerPlayer player = (entity is EntityPlayer entityPlayer) ? (IServerPlayer)entityPlayer.Player : null;
-
             var remaining = slots
                 .Select(s => entity.GetCarried(s))
                 .Where(c => c != null)
@@ -311,6 +309,15 @@ namespace CarryOn.API.Common
             }
         }
 
+        /// <summary>
+        /// Drops a specified carried block into the world as if the player entity had dropped it.
+        /// If the block cannot be placed within the specified range, it will be dropped as an item instead.
+        /// </summary>
+        /// <param name="entity"> The entity that is performing the action. </param>
+        /// <param name="carriedBlock"> The carried block to be dropped. </param>
+        /// <param name="range"> The range within which the block can be placed. </param>
+        /// <param name="blockPlacer"> The block placer to use for placing the block. </param>
+        /// <exception cref="ArgumentOutOfRangeException"> Thrown if the range is negative. </exception>
         public void DropCarriedBlock(Entity entity, CarriedBlock carriedBlock, int range = 4, BlockPlacer blockPlacer = null)
         {
             if (carriedBlock == null) return;
@@ -331,7 +338,7 @@ namespace CarryOn.API.Common
             {
                 DropBlockAsItem(carriedBlock, centerBlock, player, entity);
                 return;
-            }          
+            }
 
             if (TryPlaceDown(entity, carriedBlock, blockSelection, dropped: true))
             {

--- a/src/Common/CarryManager.cs
+++ b/src/Common/CarryManager.cs
@@ -300,7 +300,6 @@ namespace CarryOn.API.Common
                 .ToList();
             if (remaining.Count == 0) return;
 
-            BlockPos centerBlock = entity.Pos.AsBlockPos.UpCopy();
             var blockPlacer = new BlockPlacer(entity.Api);
 
             foreach (var carriedBlock in remaining)

--- a/src/Common/CarryManager.cs
+++ b/src/Common/CarryManager.cs
@@ -394,9 +394,17 @@ namespace CarryOn.API.Common
                 }
             }
 
-            var breakSound = carriedBlock.Block.Sounds.GetBreakSound(player).Location ?? new AssetLocation("game:sounds/block/planks");
-            world.PlaySoundAt(breakSound, (double)centerBlock.X, (double)centerBlock.Y, (double)centerBlock.Z);
             RemoveCarried(entity, carriedBlock.Slot);
+            
+            try
+            {
+                var breakSound = carriedBlock.Block.Sounds.GetBreakSound(player).Location ?? new AssetLocation("game:sounds/block/planks");
+                world.PlaySoundAt(breakSound, (double)centerBlock.X, (double)centerBlock.Y, (double)centerBlock.Z);
+            }
+            catch (Exception ex)
+            {
+                world.Logger.Error($"[{CarrySystem.ModId}] Failed to play block break sound for block {carriedBlock.Block.Code} at {centerBlock}. {ex}");
+            }
 
             if (blockDestroyed)
                 world.Logger.Audit($"[{CarrySystem.ModId}] Player {player?.PlayerName} dropped carried block {carriedBlock.Block.Code} at {centerBlock} and it was destroyed dropping {dropCount} items.");

--- a/src/Common/Network/CarryResyncRequestMessage.cs
+++ b/src/Common/Network/CarryResyncRequestMessage.cs
@@ -1,0 +1,22 @@
+using ProtoBuf;
+
+namespace CarryOn.Common.Network
+{
+    /// <summary>
+    /// Sent client → server when the client detects its local carry revision is behind
+    /// the server's. The server responds by re-marking the carry attribute path dirty,
+    /// causing the authoritative state to be replicated to the requesting client.
+    /// </summary>
+    [ProtoContract]
+    public class CarryResyncRequestMessage
+    {
+        private CarryResyncRequestMessage() { }
+
+        public CarryResyncRequestMessage(int localRevision)
+            => LocalRevision = localRevision;
+
+        /// <summary> The revision the client currently holds, for server-side logging. </summary>
+        [ProtoMember(1)]
+        public int LocalRevision { get; private set; }
+    }
+}

--- a/src/Common/Network/CarryRevisionMessage.cs
+++ b/src/Common/Network/CarryRevisionMessage.cs
@@ -5,8 +5,9 @@ namespace CarryOn.Common.Network
     /// <summary>
     /// Sent server → client after any forced server-side carry mutation (e.g. damage drop).
     /// The client compares its local carried revision against <see cref="Revision"/> and
-    /// cancels any in-progress interaction if the revisions do not match, relying on the
-    /// normal watched-attribute replication to restore the authoritative state.
+    /// cancels any in-progress interaction only if its local revision is behind the
+    /// authoritative revision, relying on the normal watched-attribute replication to
+    /// restore the authoritative state.
     /// </summary>
     [ProtoContract(ImplicitFields = ImplicitFields.AllFields)]
     public class CarryRevisionMessage

--- a/src/Common/Network/CarryRevisionMessage.cs
+++ b/src/Common/Network/CarryRevisionMessage.cs
@@ -1,0 +1,21 @@
+using ProtoBuf;
+
+namespace CarryOn.Common.Network
+{
+    /// <summary>
+    /// Sent server → client after any forced server-side carry mutation (e.g. damage drop).
+    /// The client compares its local carried revision against <see cref="Revision"/> and
+    /// cancels any in-progress interaction if the revisions do not match, relying on the
+    /// normal watched-attribute replication to restore the authoritative state.
+    /// </summary>
+    [ProtoContract(ImplicitFields = ImplicitFields.AllFields)]
+    public class CarryRevisionMessage
+    {
+        public int Revision { get; }
+
+        private CarryRevisionMessage() { }
+
+        public CarryRevisionMessage(int revision)
+            => Revision = revision;
+    }
+}

--- a/src/Server/EntityBehaviorDropCarriedOnDamage.cs
+++ b/src/Server/EntityBehaviorDropCarriedOnDamage.cs
@@ -1,6 +1,8 @@
 using CarryOn.API.Common;
+using CarryOn.Common;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
+using Vintagestory.GameContent;
 
 namespace CarryOn.Server
 {
@@ -20,7 +22,10 @@ namespace CarryOn.Server
         public override void OnEntityReceiveDamage(DamageSource damageSource, ref float damage)
         {
             if (damageSource.Type != EnumDamageType.Heal)
+            {
                 CarrySystem.GetCarryManager(entity?.Api)?.DropCarried(entity, DropFrom, 2);
+                CarryHandler.SendCarryRevision(entity as EntityPlayer);
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request updates the version of the Carry On mod to 1.14.1 and introduces improved error handling and recovery logic for swapping carried blocks. It also adds a new method to centralize the logic for dropping carried blocks, improving maintainability and reliability.

**Version Bump:**

* Updated the mod version to `1.14.1` in `CarryOn.csproj`, `CarryOn.json`, `resources/modinfo.json`, and `src/CarrySystem.cs` to reflect the new release. [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-23f506e8f4a47454b2af201b29acf17ae215f39a4208ee073c36b642b9f33f05L2-R2) [[3]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[4]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L24-R24)

**Error Handling and Swap Logic Improvements:**

* Enhanced the `Swap` method in `CarryableExtensions.cs` to check slot compatibility before swapping, and added robust exception handling to roll back or drop blocks if the swap fails, with appropriate error messages for both client and server.

**Codebase Improvements:**

* Added a new `DropCarriedBlock` method to `CarryManager.cs` to encapsulate the logic for dropping a carried block, and updated related code to use this method for better maintainability.
* Cleaned up unused `using` statements and improved imports in `CarryableExtensions.cs`.