### PR TITLE
Carryonmore eternalstew

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.14.0</Version>
+		<Version>1.14.1-pre.1</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>1.14.1-pre.1</Version>
+		<Version>1.14.1</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.14.1-pre.1",
+  "carryOnVersion": "1.14.1",
   "vintageStoryVersion": "1.22.0"
 }

--- a/CarryOn.json
+++ b/CarryOn.json
@@ -1,4 +1,4 @@
 {
-  "carryOnVersion": "1.14.0",
+  "carryOnVersion": "1.14.1-pre.1",
   "vintageStoryVersion": "1.22.0"
 }

--- a/resources/assets/carryon/patches/carryable/cabinet.json
+++ b/resources/assets/carryon/patches/carryable/cabinet.json
@@ -1,0 +1,21 @@
+[
+  { 
+    "file": "game:blocktypes/wood/woodtyped/cabinet",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "animation": "carryon:holdheavy",
+            "walkSpeedModifier": -0.15,
+            "rotation": [ 0, -90, 0 ],
+            "translation": [ 0, -0.3, 0.2 ]
+          }
+        }
+      }
+    }
+  }
+]

--- a/resources/assets/carryon/patches/carryonmore/eternalstew.json
+++ b/resources/assets/carryon/patches/carryonmore/eternalstew.json
@@ -1,0 +1,38 @@
+[
+  { 
+    "file": "eternalstew:blocktypes/eternalstewstove",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "interactDelay": 1.5,
+        "slots": {
+          "Hands": {
+            "animation": "carryon:holdheavy",
+            "walkSpeedModifier": -0.2,
+            "rotation": [ 0, 90, 0 ]
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "eternalstew" } ]
+  },
+  { 
+    "file": "eternalstew:blocktypes/eternalstewpot",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "eternalstew" } ]
+  }  
+]

--- a/resources/assets/carryon/patches/carryonmore/eternalstew.json
+++ b/resources/assets/carryon/patches/carryonmore/eternalstew.json
@@ -7,7 +7,7 @@
     "value": {
       "name": "Carryable",
       "properties": {
-        "interactDelay": 1.5,
+        "interactDelay": 1.7,
         "slots": {
           "Hands": {
             "animation": "carryon:holdheavy",
@@ -27,8 +27,11 @@
     "value": {
       "name": "Carryable",
       "properties": {
+        "optimisticPickup": false,
         "slots": {
           "Hands": {
+            "rotation": [ 0, 90, 0 ],
+            "translation": [ 0, -0.15, 0 ]
           }
         }
       }

--- a/resources/assets/carryon/patches/carryonmore/kevinsfurniture.json
+++ b/resources/assets/carryon/patches/carryonmore/kevinsfurniture.json
@@ -1,0 +1,144 @@
+[
+  { 
+    "file": "kevinsfurniture:blocktypes/chairs/floorcushion",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {}
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  },
+  { 
+    "file": "kevinsfurniture:blocktypes/chairs/primitivestool",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "rotation": [ 0, 90, 0 ],
+            "translation": [ 0, -0.4, 0.2]
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  },
+  { 
+    "file": "kevinsfurniture:blocktypes/tables/coffeetable",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "translation": [ 0, -0.4, 0]
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  },
+  { 
+    "file": "kevinsfurniture:blocktypes/stoveblock",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "animation": "carryon:holdheavy",
+            "walkSpeedModifier": -0.1,
+            "rotation": [ 0, -90, 0 ],
+            "translation": [ 0, -0.4, 0 ]
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  },
+  { 
+    "file": "kevinsfurniture:blocktypes/containers/anightstand",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "translation": [ 0, -0.4, 0]
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  },
+  { 
+    "file": "kevinsfurniture:blocktypes/containers/nightstand-fancy",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "translation": [ 0, -0.4, 0]
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  },
+  { 
+    "file": "kevinsfurniture:blocktypes/containers/cabinet",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "translation": [ 0, -0.4, 0],
+            "rotation": [ 0, -90, 0 ],
+            "walkSpeedModifier": -0.2
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  },
+  { 
+    "file": "kevinsfurniture:blocktypes/containers/doorlesscabinet",
+    "side": "Server",
+    "op": "add",
+    "path": "/behaviors/-",
+    "value": {
+      "name": "Carryable",
+      "properties": {
+        "slots": {
+          "Hands": {
+            "translation": [ 0, -0.4, 0],
+            "rotation": [ 0, -90, 0 ],
+            "walkSpeedModifier": -0.2
+          }
+        }
+      }
+    },
+    "dependsOn": [ { "modid": "kevinsfurniture" } ]
+  }       
+]

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.14.1-pre.1",
+	"version": "1.14.1",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "1.14.0",
+	"version": "1.14.1-pre.1",
 
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",

--- a/src/API/Common/CarriedBlock.cs
+++ b/src/API/Common/CarriedBlock.cs
@@ -18,6 +18,8 @@ namespace CarryOn.API.Common
         public static string AttributeId { get; }
             = $"{CarrySystem.ModId}:Carried";
 
+        public static string RevisionAttributeKey { get; } = "Rev";
+
         public CarrySlot Slot { get; }
 
         public ItemStack ItemStack { get; }
@@ -63,15 +65,35 @@ namespace CarryOn.API.Common
             return new CarriedBlock(slot, stack, blockEntityData);
         }
 
-        /// <summary> Stores the specified stack and blockEntityData (may be null)
-        ///           as the <see cref="CarriedBlock"/> of the entity in that slot. </summary>
+
+        /// <summary> 
+        /// Stores the specified stack and blockEntityData (may be null)
+        /// as the <see cref="CarriedBlock"/> of the entity in that slot. 
+        /// </summary>
+        /// <param name="entity"> The entity whose carried block is being set. </param>
+        /// <param name="slot"> The slot in which to set the carried block. </param>
+        /// <param name="stack"> The item stack to set as the carried block. </param>
+        /// <param name="blockEntityData"> The block entity data to set (may be null). </param>
         /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
         public static void Set(Entity entity, CarrySlot slot, ItemStack stack, ITreeAttribute blockEntityData)
+            => Set(entity, slot, stack, blockEntityData, true);
+
+        /// <summary>
+        ///  Stores the specified stack and blockEntityData (may be null)
+        ///  as the <see cref="CarriedBlock"/> of the entity in that slot. 
+        /// </summary>
+        /// <param name="entity"> The entity whose carried block is being set. </param>
+        /// <param name="slot"> The slot in which to set the carried block. </param>
+        /// <param name="stack"> The item stack to set as the carried block. </param>
+        /// <param name="blockEntityData"> The block entity data to set (may be null). </param>
+        /// <param name="markDirty"> Whether to mark the entity's watched attributes as dirty after setting. If false, the caller must manually mark dirty for changes to sync. </param>
+        /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
+        public static void Set(Entity entity, CarrySlot slot, ItemStack stack, ITreeAttribute blockEntityData, bool markDirty = true)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
 
             entity.WatchedAttributes.Set(stack, AttributeId, slot.ToString(), "Stack");
-            ((SyncedTreeAttribute)entity.WatchedAttributes).MarkPathDirty(AttributeId);
+            if (markDirty) TouchCarriedAttributes(entity);
 
             if ((entity.World.Side == EnumAppSide.Server) && (blockEntityData != null))
                 entity.Attributes.Set(blockEntityData, AttributeId, slot.ToString(), "Data");
@@ -103,10 +125,16 @@ namespace CarryOn.API.Common
         public void Set(Entity entity, CarrySlot slot)
             => Set(entity, slot, ItemStack, BlockEntityData);
 
+        public void Set(Entity entity, CarrySlot slot, bool markDirty = true)
+            => Set(entity, slot, ItemStack, BlockEntityData, markDirty);            
+
+        public static void Remove(Entity entity, CarrySlot slot)
+            => Remove(entity, slot, true);
+
         /// <summary> Removes the <see cref="CarriedBlock"/>
         ///           carried by the specified entity in that slot. </summary>
         /// <exception cref="ArgumentNullException"> Thrown if entity is null. </exception>
-        public static void Remove(Entity entity, CarrySlot slot)
+        public static void Remove(Entity entity, CarrySlot slot, bool markDirty = true)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
 
@@ -123,9 +151,41 @@ namespace CarryOn.API.Common
             }
 
             entity.WatchedAttributes.Remove(AttributeId, slot.ToString());
-            ((SyncedTreeAttribute)entity.WatchedAttributes).MarkPathDirty(AttributeId);
+            if (markDirty) TouchCarriedAttributes(entity);
             entity.Attributes.Remove(AttributeId, slot.ToString());
         }
+
+        /// <summary>
+        /// Increments the carried-state revision and marks the carried root dirty if necessary.
+        /// Client side only returns the current revision, while server side increments and returns the new revision.
+        /// </summary>
+        /// <param name="entity">The entity whose carried attributes are being touched.</param>
+        /// <returns> The new revision number. </returns>
+        public static int TouchCarriedAttributes(Entity entity)
+        {
+            if (entity == null) throw new ArgumentNullException(nameof(entity));
+
+            var carriedRoot = entity.WatchedAttributes.TryGet<ITreeAttribute>(AttributeId) ?? new TreeAttribute();
+            var revision = carriedRoot.GetInt(RevisionAttributeKey, 0);
+
+            // Only server has authority to update the revision 
+            if (entity.World.Side == EnumAppSide.Server)
+            {
+                carriedRoot.SetInt(RevisionAttributeKey, ++revision);
+                entity.WatchedAttributes.Set(carriedRoot, AttributeId);
+                entity.WatchedAttributes.MarkPathDirty(AttributeId);
+            }
+
+            return revision;
+        }
+
+        public static int GetCarriedRevision(Entity entity)
+        {
+            if (entity == null) throw new ArgumentNullException(nameof(entity));
+            var carriedRoot = entity.WatchedAttributes.TryGet<ITreeAttribute>(AttributeId);
+            return carriedRoot?.GetInt(RevisionAttributeKey, 0) ?? 0;
+        }
+
 
         /// <summary> Creates a <see cref="CarriedBlock"/> from the specified world
         ///           and position, but doesn't remove it. Returns null if unsuccessful. </summary>

--- a/src/API/Common/CarriedBlock.cs
+++ b/src/API/Common/CarriedBlock.cs
@@ -306,7 +306,7 @@ namespace CarryOn.API.Common
         }
 
         public void PlaySound(BlockPos pos, IWorldAccessor world,
-                        EntityPlayer entityPlayer = null)
+                        EntityPlayer entityPlayer = null, bool dualCall = true)
         {
             const float SOUND_RANGE = 16.0F;
             const float SOUND_VOLUME = 1.0F;
@@ -316,7 +316,7 @@ namespace CarryOn.API.Common
             // TODO: In 1.7.0, Block.Sounds should not be null anymore.
             if (placeSound == null) return;
 
-            var player = (entityPlayer != null) && (world.Side == EnumAppSide.Server)
+            var player = dualCall && (entityPlayer != null) && (world.Side == EnumAppSide.Server)
                 ? entityPlayer?.Player : null;
 
             world.PlaySoundAt(location: placeSound.Value.Location,

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -160,15 +160,19 @@ namespace CarryOn.API.Common
         {
             if (first == second) throw new ArgumentException("Slots can't be the same");
 
+            bool isServer = entity.Api.Side == EnumAppSide.Server;
+
             var carriedFirst = CarriedBlock.Get(entity, first);
             var carriedSecond = CarriedBlock.Get(entity, second);
             if ((carriedFirst == null) && (carriedSecond == null)) return false;
 
-            CarriedBlock.Remove(entity, first);
-            CarriedBlock.Remove(entity, second);
+            CarriedBlock.Remove(entity, first, markDirty: false);
+            CarriedBlock.Remove(entity, second, markDirty: false);
 
-            carriedFirst?.Set(entity, second);
-            carriedSecond?.Set(entity, first);
+            carriedFirst?.Set(entity, second, markDirty: false);
+            carriedSecond?.Set(entity, first, markDirty: false);
+
+            if (isServer) CarriedBlock.TouchCarriedAttributes(entity);
 
             return true;
         }

--- a/src/API/Common/CarryableExtensions.cs
+++ b/src/API/Common/CarryableExtensions.cs
@@ -73,16 +73,29 @@ namespace CarryOn.API.Common
         {
             if (!HasPermissionToCarry(entity, pos)) return false;
             if (CarriedBlock.Get(entity, slot) != null) return false;
+
+            var block = entity.World.BlockAccessor.GetBlock(pos);
+            if (checkIsCarryable && !block.IsCarryable(slot)) return false;
+
+            var carryBehavior = block.GetBehavior<BlockBehaviorCarryable>();
+            if ((entity.Api.Side == EnumAppSide.Client) && (carryBehavior != null) && !carryBehavior.OptimisticPickup)
+            {
+                // Let the server perform the pickup when optimistic client pickup is disabled.
+                return true;
+            }
+
+            var optimisticPickup = carryBehavior?.OptimisticPickup ?? true;
+
             var carried = CarriedBlock.PickUp(entity.World, pos, slot, checkIsCarryable);
             if (carried == null) return false;
 
             carried.Set(entity, slot);
-            if (playSound) carried.PlaySound(pos, entity.World, entity as EntityPlayer);
+            if (playSound) carried.PlaySound(pos, entity.World, entity as EntityPlayer, dualCall: optimisticPickup);
             if (entity.Api.Side == EnumAppSide.Server)
             {
                 var entityName = entity?.GetName() ?? "Unknown Entity";
                 entity.World.Logger.Audit($"[{CarrySystem.ModId}] {entityName} picked up block {carried.Block.Code.GetName()} at {pos}");
-            }            
+            }
             return true;
         }
 

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.14.0",
+    Version = "1.14.1-pre.1",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,7 +21,7 @@ using Vintagestory.GameContent;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "1.14.1-pre.1",
+    Version = "1.14.1",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/Common/BlockBehaviorCarryable.cs
+++ b/src/Common/BlockBehaviorCarryable.cs
@@ -60,6 +60,8 @@ namespace CarryOn.Common
 
         public bool PreventAttaching { get; private set; } = false;
 
+        public bool OptimisticPickup { get; private set; } = true;
+
         public BlockBehaviorCarryable(Block block)
             : base(block) { }
 
@@ -74,6 +76,8 @@ namespace CarryOn.Common
             if (JsonHelper.TryGetFloat(properties, "interactDelay", out var d)) InteractDelay = d;
 
             if (JsonHelper.TryGetBool(properties, "preventAttaching", out var a)) PreventAttaching = a;
+
+            if (JsonHelper.TryGetBool(properties, "optimisticPickup", out var o)) OptimisticPickup = o;
 
             DefaultTransform = JsonHelper.GetTransform(properties, DefaultBlockTransform);
             Slots.Initialize(properties["slots"], DefaultTransform);

--- a/src/Common/CarryHandler.cs
+++ b/src/Common/CarryHandler.cs
@@ -842,7 +842,6 @@ namespace CarryOn.Common
                 if (player.Entity.Swap(message.First, message.Second))
                 {
                     CarrySystem.Api.World.PlaySoundAt(new AssetLocation("sounds/player/throw"), player.Entity);
-                    CarriedBlock.TouchCarriedAttributes(player.Entity);
                 }
             }
         }

--- a/src/Common/CarryHandler.cs
+++ b/src/Common/CarryHandler.cs
@@ -842,7 +842,7 @@ namespace CarryOn.Common
                 if (player.Entity.Swap(message.First, message.Second))
                 {
                     CarrySystem.Api.World.PlaySoundAt(new AssetLocation("sounds/player/throw"), player.Entity);
-                    player.Entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+                    CarriedBlock.TouchCarriedAttributes(player.Entity);
                 }
             }
         }
@@ -1210,7 +1210,7 @@ namespace CarryOn.Common
         private void InvalidCarry(IServerPlayer player, BlockPos pos)
         {
             player.Entity.World.BlockAccessor.MarkBlockDirty(pos);
-            player.Entity.WatchedAttributes.MarkPathDirty(CarriedBlock.AttributeId);
+            CarriedBlock.TouchCarriedAttributes(player.Entity);
             player.Entity.WatchedAttributes.MarkPathDirty("stats/walkspeed");
             SendLockSlotsMessage(player);
         }


### PR DESCRIPTION
This pull request updates the mod version to `1.14.1-pre.1` and introduces several improvements and fixes to the carried block system, particularly around synchronization, client-server pickup logic, and support for new modded blocks. The most important changes are grouped below.

**Version and Mod Support Updates:**

* Updated all version references to `1.14.1-pre.1` in `CarryOn.csproj`, `CarryOn.json`, `modinfo.json`, and `CarrySystem.cs`. [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-23f506e8f4a47454b2af201b29acf17ae215f39a4208ee073c36b642b9f33f05L2-R2) [[3]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[4]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L24-R24)
* Added carry support for "eternalstew" mod blocks (`eternalstewstove` and `eternalstewpot`) via a new patch file.

**Carried Block State and Synchronization Improvements:**

* Introduced a revision tracking system for carried block state (`RevisionAttributeKey`, `TouchCarriedAttributes`, and `GetCarriedRevision`) to improve synchronization and allow more efficient and reliable updates. [[1]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dR21-R22) [[2]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dL66-R96) [[3]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dR128-R137) [[4]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dL126-R189)
* Refactored `Set` and `Remove` methods for carried blocks to support a `markDirty` parameter, allowing for batched updates and more control over when the state is marked as dirty. [[1]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dL66-R96) [[2]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dR128-R137)
* Updated swap logic to batch carried block updates and only mark dirty once, improving efficiency and consistency. [[1]](diffhunk://#diff-b812d5af6c0bd116c06598696511034bbe4ac0445db2f6739b0ffb7d75cb4898R163-R175) [[2]](diffhunk://#diff-5ca699202b9bda65c359d9d6678c90906f99b0f9dea17f94da0d67d0ba32dac9L845-R845)

**Carryable Behavior and Client-Server Logic:**

* Added the `OptimisticPickup` property to `BlockBehaviorCarryable`, configurable via JSON, to control whether clients can optimistically pick up blocks or must wait for server confirmation. [[1]](diffhunk://#diff-b8dac24dfa28b8355367f31bdbe6c822551f5040ac76d70f036a074aa92fce5cR63-R64) [[2]](diffhunk://#diff-b8dac24dfa28b8355367f31bdbe6c822551f5040ac76d70f036a074aa92fce5cR80-R81)
* Updated carry logic to honor the `OptimisticPickup` setting, ensuring correct pickup behavior for blocks that require server authority.

**Sound and Visual Feedback Improvements:**

* Modified the `PlaySound` method to accept a `dualCall` parameter, forcing server to trigger sounds for player when optimistic pickup is disabled. [[1]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dL309-R369) [[2]](diffhunk://#diff-9b003b9e6f0382fa6b5e9ddca321d3d6b711ec283981ef37be3471c9f28f743dL319-R379)

**Bug Fixes and Minor Improvements:**

* Ensured carried block state is properly marked dirty after invalid carry attempts, improving client synchronization.