### PR TITLE
Update cabinet and reedchest patches with condition and speed adjustments

### DIFF
--- a/docs/carryon-config.md
+++ b/docs/carryon-config.md
@@ -52,6 +52,7 @@ Default values:
 | `Barrel` | `true` |
 | `Bookshelf` | `false` |
 | `BunchOCandles` | `false` |
+| `Cabinet` | `true` |
 | `Chandelier` | `false` |
 | `ChestTrunk` | `false` |
 | `Chest` | `true` |

--- a/docs/vanilla-block-inventory.md
+++ b/docs/vanilla-block-inventory.md
@@ -19,7 +19,7 @@ Walk speed values shown are explicit overrides. A blank entry means the slot's c
 | game:blocktypes/wood/bookshelf-clutter* | `carryon.Carryables.Clutter & Bookshelf` | Yes | — | — | 0.8 / 0.6 / 1.2 | — | — | — |
 | game:blocktypes/legacy/bookshelves | `carryon.Carryables.Bookshelf` | Yes | — | — | 0.8 / 0.6 / 1.2 | — | — | — |
 | game:blocktypes/wax/bunchocandles | `carryon.Carryables.BunchOCandles` | Yes | — | — | 0.8 / 0.6 / 1.2 | — | — | — |
-| game:blocktypes/wood/woodtyped/cabinet | *(always enabled)* | Yes | — | -0.15 / — | 0.8 / 0.6 / 1.2 | — | — | — |
+| game:blocktypes/wood/woodtyped/cabinet | `carryon.Carryables.Cabinet` | Yes | — | -0.15 / — | 0.8 / 0.6 / 1.2 | — | — | — |
 | game:blocktypes/metal/chandelier | `carryon.Carryables.Chandelier` | Yes | — | — | 0.8 / 0.6 / 1.2 | — | — | — |
 | game:blocktypes/wood/chest | `carryon.Carryables.Chest` | Yes | Yes | — | 0.8 / 0.6 / 1.2 | `carryon.CarryablesOnBack.Chest` | Yes | carryon:carry-chest, carryon:carry-chest-compact |
 | game:blocktypes/wood/chest-labeled | `carryon.Carryables.Chest` | Yes | Yes | — | 0.8 / 0.6 / 1.2 | `carryon.CarryablesOnBack.Chest` | Yes | carryon:carry-chest |
@@ -39,7 +39,7 @@ Walk speed values shown are explicit overrides. A blank entry means the slot's c
 | game:blocktypes/clay/fired/planter | `carryon.Carryables.Planter` | Yes | Yes | — | 0.8 / 0.6 / 1.2 | `carryon.CarryablesOnBack.Planter` | — | carryon:plants-large, carryon:carry-planter |
 | game:blocktypes/metal/plaque | `carryon.Carryables.Sign` ¹ | Yes | — | -0.50 / — | 0.8 / 0.6 / 1.2 | — | — | — |
 | game:blocktypes/stone/quern | `carryon.Carryables.Quern` | Yes | — | -0.40 / — | 1.0 / 0.75 / 1.5 | — | — | — |
-| game:blocktypes/reed/reedchest | `carryon.Carryables.ReedChest` | Yes | Yes | -0.15 / — | 0.4 / 0.3 / 0.6 | `carryon.CarryablesOnBack.ReedChest` | Yes | carryon:carry-reedchest |
+| game:blocktypes/reed/reedchest | `carryon.Carryables.ReedChest` | Yes | Yes | -0.15 / 0.0 | 0.4 / 0.3 / 0.6 | `carryon.CarryablesOnBack.ReedChest` | Yes | carryon:carry-reedchest |
 | game:blocktypes/machine/resonator | `carryon.Carryables.Resonator` | Yes | — | -0.15 / — | 0.4 / 0.3 / 0.6 | — | — | — |
 | game:blocktypes/wood/shelf | `carryon.Carryables.Shelf` | Yes | — | — | 0.8 / 0.6 / 1.2 | — | — | — |
 | game:blocktypes/wood/sign | `carryon.Carryables.Sign` | Yes | — | — | 0.8 / 0.6 / 1.2 | — | — | — |
@@ -50,8 +50,6 @@ Walk speed values shown are explicit overrides. A blank entry means the slot's c
 
 ¹ Banner and plaque share another block type's config key rather than having their own.  
 ² Ingot mold and tool mold both use the shared `Mold` config key.
-
-The `cabinet` patch carries no `enabledCondition` and is always applied when CarryOn is installed.
 
 The `log-withresin` patch uses `behaviorsByType` to target all variants plus a separate entry for the `log-resinharvested-*` state with different transform groups.
 

--- a/resources/assets/carryon/patches/carryable/cabinet.json
+++ b/resources/assets/carryon/patches/carryable/cabinet.json
@@ -7,6 +7,7 @@
 		"value": {
 			"name": "Carryable",
 			"properties": {
+				"enabledCondition": "carryon.Carryables.Cabinet",
 				"transformGroups": {
 					"hands": [
 						{

--- a/resources/assets/carryon/patches/carryable/reedchest.json
+++ b/resources/assets/carryon/patches/carryable/reedchest.json
@@ -19,6 +19,7 @@
 					},
 					"Back": {
 						"enabledCondition": "carryon.CarryablesOnBack.ReedChest",
+            "walkSpeedModifier": 0.0,
 						"excludedTypes": [
 							"aged",
 							"aged2"

--- a/resources/assets/carryon/patches/carryable/reedchest.json
+++ b/resources/assets/carryon/patches/carryable/reedchest.json
@@ -19,7 +19,7 @@
 					},
 					"Back": {
 						"enabledCondition": "carryon.CarryablesOnBack.ReedChest",
-            "walkSpeedModifier": 0.0,
+						"walkSpeedModifier": 0.0,
 						"excludedTypes": [
 							"aged",
 							"aged2"

--- a/resources/assets/carryon/patches/carryonmore/labeledcontainers.json
+++ b/resources/assets/carryon/patches/carryonmore/labeledcontainers.json
@@ -69,7 +69,6 @@
 			}
 		]
 	},
-
 	{
 		"file": "lcupdated:blocktypes/stationarybasket",
 		"side": "Server",
@@ -139,5 +138,5 @@
 				"modid": "lcupdated"
 			}
 		]
-	}	
+	}
 ]

--- a/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
+++ b/resources/assets/carryon/patches/carryonmore/labeledtrunks.json
@@ -17,7 +17,7 @@
 						"rotation": [ 0.0, -90.0, 0.0 ],
 						"scale": 1.0
 					}
-				},				
+				},
 				"slots": {
 					"Hands": {
 						"animation": "carryon:holdheavy",


### PR DESCRIPTION
This pull request updates the carryable item configuration for the cabinet and reed chest blocks to improve consistency and clarity in both documentation and patch files. The main changes include adding explicit `enabledCondition` and walk speed modifier properties, as well as aligning documentation to reflect these updates.

**Carryable item configuration updates:**

* Added an explicit `enabledCondition` property (`carryon.Carryables.Cabinet`) to the `cabinet.json` patch, ensuring the cabinet's carryable status is controlled by this condition.
* Updated the reed chest's back-carry configuration in `reedchest.json` to set a `walkSpeedModifier` of `0.0`, clarifying its effect when carried on the back.

**Documentation alignment and clarification:**

* Updated the cabinet entry in `docs/vanilla-block-inventory.md` to specify the correct `enabledCondition` (`carryon.Carryables.Cabinet`) instead of indicating it is always enabled.
* Changed the reed chest entry in `docs/vanilla-block-inventory.md` to show the updated walk speed modifier values (`-0.15 / 0.0`) for consistency with the patch.
* Removed outdated documentation note stating the cabinet patch is always enabled, as it now uses an explicit `enabledCondition`.