### PR TITLE
Refactor chat commands and update carryable block configuration

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>2.0.0-pre.2</Version>
+		<Version>2.0.0-pre.3</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/docs/carryon-chat-commands.md
+++ b/docs/carryon-chat-commands.md
@@ -10,19 +10,6 @@ Carry On exposes a client-side `.carryon` chat command tree for gameplay toggles
 
 ## Top-Level Commands
 
-### `.carryon carriedlight true|false`
-
-Enables or disables carried block lighting for all players.
-
-- `true` enables carried light.
-- `false` disables carried light and resets player light state on the client.
-
-Example:
-
-```text
-.carryon carriedlight false
-```
-
 ## GUI Debug Commands
 
 The `.carryon gui` branch manages the on-screen carry HUD anchors and visual styling.

--- a/docs/carryon-config.md
+++ b/docs/carryon-config.md
@@ -160,7 +160,7 @@ This option is commonly used to avoid accidental swap/back actions when interact
     "game:chest*": { "Back": -0.15 }
   },
   "ByBlockClass": {
-    "BlockMushroom": { "Hands": -0.10 }
+    "BlockCrate": { "Hands": -0.80 }
   },
   "SlotDefaults": {
     "Hands": -0.25,

--- a/docs/carryon-config.md
+++ b/docs/carryon-config.md
@@ -154,7 +154,10 @@ This option is commonly used to avoid accidental swap/back actions when interact
   "ByBlockCode": {
     "game:stationarybasket*": { "Back": -0.10 },
     "lc:lblstationarybasket*": { "Back": -0.10 },
-    "lcupdated:lblstationarybasket*": { "Back": -0.10 }
+    "lcupdated:lblstationarybasket*": { "Back": -0.10 },
+    "game:chest*|owl*": { "Back": -0.08 },
+    "game:chest*|golden*": { "Back": -0.10 },
+    "game:chest*": { "Back": -0.15 }
   },
   "ByBlockClass": {
     "BlockMushroom": { "Hands": -0.10 }
@@ -168,7 +171,7 @@ This option is commonly used to avoid accidental swap/back actions when interact
 
 `WalkSpeedOverrides` notes:
 
-- `ByBlockCode`: matches full block code strings. Supports exact entries and trailing `*` prefix patterns.
+- `ByBlockCode`: matches full block code strings. Supports exact entries and trailing `*` prefix patterns. Keys may include an optional `|type` suffix to match the block's carry type (the same type resolved by `walkSpeedModifierByBlockType` in patches). For example, `"game:chest*|owl*"` matches any chest variant whose type starts with `owl`. Among matching entries, the most specific block-code prefix wins; ties are broken by type-pattern specificity. Entries without `|type` match regardless of type, but lose to type-constrained entries with equal block-code specificity.
 - `ByBlockClass`: matches block `class` names (for example `BlockMushroom`).
 - `SlotDefaults`: optional fallback values used only when a carry slot has no resolved slot value.
 

--- a/docs/modding-guide.md
+++ b/docs/modding-guide.md
@@ -199,6 +199,8 @@ Example for chest compact variants:
 }
 ```
 
+These per-slot type and group values can be overridden from the world config using the `|type` pipe syntax in `ByBlockCode` (see `carryon-config.md`). For example, `"game:chest*|owl*": { "Back": -0.05 }` overrides the owl-type Back speed regardless of what the patch defines.
+
 **Slot defaults** when properties are not specified:
 
 | Slot | Default walk speed modifier | Default animation |

--- a/docs/technical-overview/entity-carry-renderer-pipeline.md
+++ b/docs/technical-overview/entity-carry-renderer-pipeline.md
@@ -133,7 +133,6 @@ Label subsystem responsibilities:
 - Retrieves entity carried list.
 - Determines local player / first-person / immersive first-person context.
 - Retrieves entity shape renderer and animator.
-- Optionally merges carried block/item light into `entity.LightHsv` when `CarriedLightEnabled` is active.
 - Calls `RenderCarried` for each carried block.
 
 `RenderCarried` path highlights:

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "2.0.0-pre.2",
+	"version": "2.0.0-pre.3",
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",
 	"authors": [
@@ -11,6 +11,6 @@
 	],
 	"dependencies": {
 		"game": "1.22.0",
-		"carryonlib": "1.0.0-pre.2"
+		"carryonlib": "1.0.0-pre.3"
 	}
 }

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -21,12 +21,12 @@ using static CarryOn.API.Common.Models.CarryCode;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "2.0.0-pre.2",
+    Version = "2.0.0-pre.3",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]
 [assembly: ModDependency("game", "1.22.0")]
-[assembly: ModDependency("carryonlib", "1.0.0-pre.2")]
+[assembly: ModDependency("carryonlib", "1.0.0-pre.3")]
 
 namespace CarryOn
 {

--- a/src/Client/Logic/CarryRenderer/EntityCarryRenderer.cs
+++ b/src/Client/Logic/CarryRenderer/EntityCarryRenderer.cs
@@ -455,13 +455,6 @@ namespace CarryOn.Client.Logic.CarryRenderer
 		/// <summary> Renders all carried blocks of the specified entity. </summary>
 		private void RenderAllCarried(EntityAgent entity, float deltaTime, EnumRenderStage stage, bool isShadowPass)
 		{
-			var config = this.carrySystem.ClientConfig?.Config;
-			if (config?.CarriedLightEnabled == true)
-			{
-				// Reset light so carried block light can be added later
-				entity.LightHsv = new ThreeBytes(0);
-			}
-
 			var allCarried = entity.GetCarried()?.ToList() ?? [];
 			if (allCarried.Count == 0) return; // Entity is not carrying anything.
 
@@ -475,25 +468,6 @@ namespace CarryOn.Client.Logic.CarryRenderer
 
 			// Rendered not ready?
 			if (renderer == null) return;
-
-			if (config?.CarriedLightEnabled == true)
-			{
-				// Merge carried block light into entity light so that it applies to the entity and all carried blocks, without needing to modify each CarriedRenderInfo.
-				var lightHsv = entity.LightHsv;
-				foreach (var carried in allCarried)
-				{
-					switch (carried.ItemStack?.Collectible)
-					{
-						case Block block:
-							lightHsv = ColorUtil.MergeLightHSV(block.LightHsv, lightHsv);
-							break;
-						case Item item:
-							lightHsv = ColorUtil.MergeLightHSV(item.LightHsv, lightHsv);
-							break;
-					}
-				}
-				entity.LightHsv = lightHsv;
-			}
 
 			foreach (var carried in allCarried)
 			{

--- a/src/Client/Logic/ClientCommands.cs
+++ b/src/Client/Logic/ClientCommands.cs
@@ -4,7 +4,6 @@ namespace CarryOn.Client.Logic
     using CarryOn.Client.Models;
     using CarryOn.Utility;
     using Vintagestory.API.Common;
-    using Vintagestory.API.MathTools;
 
     public class ClientCommands
 
@@ -26,11 +25,6 @@ namespace CarryOn.Client.Logic
             try
             {
                 api.ChatCommands.Create("carryon")
-                    .BeginSubCommand("carriedlight")
-                        .WithDescription("Enable or disable carried block lighting for all players. Usage: .carryon carriedlight true|false")
-                        .WithArgs(api.ChatCommands.Parsers.Bool("enabled"))
-                        .HandleWith(this.CmdCarryOnCarriedLight)
-                    .EndSubCommand()
                     .BeginSubCommand("gui")
                         // .carryon gui bg ... (background fill settings)
                         .BeginSubCommand("bg")
@@ -143,38 +137,6 @@ namespace CarryOn.Client.Logic
             catch (System.Exception ex)
             {
                 api.World.Logger.Warning("CarryOn: Failed to register client chat command for GUI debug: " + ex.Message);
-            }
-        }
-
-        protected TextCommandResult CmdCarryOnCarriedLight(TextCommandCallingArgs args)
-        {
-            bool enabled = args[0] is bool enabledVal ? enabledVal : throw new InvalidOperationException("expected bool");
-
-            var clientConfig = this.carrySystem?.ClientConfig;
-
-            if (clientConfig == null || clientConfig.Config == null)
-            {
-                return TextCommandResult.Error("Client config not available. Cannot update carried block lighting setting.");
-            }
-
-            clientConfig.Config.CarriedLightEnabled = enabled;
-
-            clientConfig.Save(this.api);
-
-            if (!enabled)
-            {
-                // Reset LightHsv for all player entities
-                foreach (var player in api.World.AllPlayers)
-                {
-                    var entity = player.Entity;
-                    entity?.LightHsv = new ThreeBytes(0);
-                }
-                return TextCommandResult.Success("Carried block lighting disabled. All player lights reset.");
-            }
-            else
-            {
-                // Optionally, re-enable by triggering attribute update (if needed)
-                return TextCommandResult.Success("Carried block lighting enabled.");
             }
         }
 

--- a/src/Client/Models/ClientModConfig.cs
+++ b/src/Client/Models/ClientModConfig.cs
@@ -13,9 +13,6 @@ namespace CarryOn.Client.Models
     {
         public int? ConfigVersion { get; set; }
 
-        // Enables mixing of carried item LightHsv with the player's light when a block or item is carried.
-        public bool CarriedLightEnabled { get; set; } = true;
-
         // Stored as the enum name (L1,L2,...). "None" indicates not assigned.
         public string HandsAnchor { get; set; } = HudCarried.HandsAnchorDefault.ToString();
         public string BackAnchor { get; set; } = HudCarried.BackAnchorDefault.ToString();

--- a/src/Common/Logic/WalkSpeedModifierResolver.cs
+++ b/src/Common/Logic/WalkSpeedModifierResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CarryOn.API.Common.Models;
 using CarryOn.Common.Behaviors;
@@ -22,7 +23,9 @@ namespace CarryOn.Common.Logic
 
             if (configured != null)
             {
-                if (TryResolveByBlockCode(configured, block, slot, out var byCode))
+                var carryType = ResolveCarryType(stack);
+
+                if (TryResolveByBlockCode(configured, block, carryType, slot, out var byCode))
                 {
                     return byCode;
                 }
@@ -61,6 +64,7 @@ namespace CarryOn.Common.Logic
         private static bool TryResolveByBlockCode(
             WalkSpeedOverridesConfig configured,
             Block? block,
+            string? carryType,
             CarrySlot slot,
             out float speed)
         {
@@ -73,22 +77,91 @@ namespace CarryOn.Common.Logic
                 return false;
             }
 
-            if (JsonHelper.TryGetValueTrimmedIgnoreCase(map, blockCode, out var exact)
-                && exact != null
-                && TryGetSpeedFromSlotConfig(exact, slot, out speed))
+            CarrySlotSpeedConfig? bestConfig = null;
+            var bestBlockScore = -1;
+            var bestTypeScore = -1;
+
+            foreach (var entry in map)
             {
-                return true;
+                if (entry.Value == null) continue;
+
+                var key = entry.Key?.Trim();
+                if (string.IsNullOrWhiteSpace(key)) continue;
+
+                var pipeIndex = key.IndexOf('|');
+                string blockPattern;
+                string? typePattern;
+                if (pipeIndex >= 0)
+                {
+                    blockPattern = key.Substring(0, pipeIndex);
+                    typePattern = key.Substring(pipeIndex + 1);
+                }
+                else
+                {
+                    blockPattern = key;
+                    typePattern = null;
+                }
+
+                if (string.IsNullOrWhiteSpace(blockPattern)) continue;
+
+                int blockScore;
+                if (blockPattern.EndsWith("*", StringComparison.Ordinal))
+                {
+                    var prefix = blockPattern.Substring(0, blockPattern.Length - 1);
+                    if (!blockCode.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    blockScore = prefix.Length;
+                }
+                else
+                {
+                    if (!string.Equals(blockCode, blockPattern, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    blockScore = int.MaxValue;
+                }
+
+                int typeScore;
+                if (typePattern != null)
+                {
+                    if (string.IsNullOrWhiteSpace(carryType))
+                        continue;
+
+                    if (typePattern.EndsWith("*", StringComparison.Ordinal))
+                    {
+                        var typePrefix = typePattern.Substring(0, typePattern.Length - 1);
+                        if (!carryType.StartsWith(typePrefix, StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        typeScore = typePrefix.Length;
+                    }
+                    else if (string.IsNullOrEmpty(typePattern))
+                    {
+                        if (!string.IsNullOrEmpty(carryType))
+                            continue;
+                        typeScore = 0;
+                    }
+                    else
+                    {
+                        if (!string.Equals(carryType, typePattern, StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        typeScore = int.MaxValue;
+                    }
+                }
+                else
+                {
+                    typeScore = -1;
+                }
+
+                if (blockScore > bestBlockScore
+                    || (blockScore == bestBlockScore && typeScore > bestTypeScore))
+                {
+                    bestConfig = entry.Value;
+                    bestBlockScore = blockScore;
+                    bestTypeScore = typeScore;
+                }
             }
 
-            if (JsonHelper.TryGetTrailingWildcardValue(
-                    map,
-                    blockCode,
-                    out CarrySlotSpeedConfig? wildcardConfig,
-                    static value => value is not null)
-                && wildcardConfig is not null
-                && TryGetSpeedFromSlotConfig(wildcardConfig, slot, out speed))
+            if (bestConfig != null)
             {
-                return true;
+                return TryGetSpeedFromSlotConfig(bestConfig, slot, out speed);
             }
 
             return false;

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
-  "modVersion": "2.0.0-pre.2",
+  "modVersion": "2.0.0-pre.3",
   "dependencies": {
     "game": "1.22.0",
-    "carryonlib": "1.0.0-pre.2"
+    "carryonlib": "1.0.0-pre.3"
   }
 }


### PR DESCRIPTION
This pull request introduces a new pre-release version (`2.0.0-pre.3`) of the Carry On mod, removes the client-side carried block lighting feature and its associated chat command, and adds advanced configuration options for walk speed modifiers using a new `|type` pipe syntax. The changes also update documentation to match these code changes and improve the walk speed modifier resolver logic for more flexible and precise matching.

### Version and Dependency Updates
* Bumped the mod version to `2.0.0-pre.3` and updated the dependency on `carryonlib` to `1.0.0-pre.3` in all relevant files (`CarryOn.csproj`, `modinfo.json`, `CarrySystem.cs`, `version.json`). [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[3]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L14-R14) [[4]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L24-R29) [[5]](diffhunk://#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL2-R5)

### Removal of Carried Block Lighting Feature
* Removed the `CarriedLightEnabled` option from the client config, the `.carryon carriedlight` chat command, and all related code and documentation. Carried block lighting can no longer be toggled by players. [[1]](diffhunk://#diff-44cc9f2cbd293a94f6d9a801921a26a294c2b7b838a18e9c001cd6eabc822ce9L29-L33) [[2]](diffhunk://#diff-44cc9f2cbd293a94f6d9a801921a26a294c2b7b838a18e9c001cd6eabc822ce9L149-L180) [[3]](diffhunk://#diff-0924117ca066e473392fa1964ca6cc9ceb770b6cf09c5b3ab0bfd979963b8b68L16-L18) [[4]](diffhunk://#diff-0be14df6cf7fe6e734522946b015f700f4b1c02d8bf6215b1bfdf1eba8b764cdL13-L25) [[5]](diffhunk://#diff-2a29d8f7ec56d7c0b662018999de25f33afdc21cd2d86a77c03df16249604b96L136) [[6]](diffhunk://#diff-cbe71c19d206399216b97e7b592da88627aab9358597917b36ce830fc36127d3L458-L464) [[7]](diffhunk://#diff-cbe71c19d206399216b97e7b592da88627aab9358597917b36ce830fc36127d3L479-L497)

### Walk Speed Modifier Configuration Enhancements
* Added support for the `|type` pipe syntax in `ByBlockCode` configuration, allowing walk speed overrides to be specified based on both block code and carry type. The resolver now selects the most specific match, prioritizing type-constrained entries. [[1]](diffhunk://#diff-c7f905293f3d9f623a219ccc0916fdb7b5e1951eb2acc59ee7d428722ee5a587L157-R163) [[2]](diffhunk://#diff-c7f905293f3d9f623a219ccc0916fdb7b5e1951eb2acc59ee7d428722ee5a587L171-R174) [[3]](diffhunk://#diff-ff4f69bb7eeef76cb733eff6d6f09244ea43fc464f7a103b91fdabf4809aea88R202-R203) [[4]](diffhunk://#diff-635abe9372a1fca726c7be9e84f948f6e70e0125c2015a23224dd5cf1cf043c5R1) [[5]](diffhunk://#diff-635abe9372a1fca726c7be9e84f948f6e70e0125c2015a23224dd5cf1cf043c5L25-R28) [[6]](diffhunk://#diff-635abe9372a1fca726c7be9e84f948f6e70e0125c2015a23224dd5cf1cf043c5R67) [[7]](diffhunk://#diff-635abe9372a1fca726c7be9e84f948f6e70e0125c2015a23224dd5cf1cf043c5L76-R164)
* Updated example configurations and documentation to show how to use the new `|type` syntax for fine-grained control. [[1]](diffhunk://#diff-c7f905293f3d9f623a219ccc0916fdb7b5e1951eb2acc59ee7d428722ee5a587L157-R163) [[2]](diffhunk://#diff-c7f905293f3d9f623a219ccc0916fdb7b5e1951eb2acc59ee7d428722ee5a587L171-R174) [[3]](diffhunk://#diff-ff4f69bb7eeef76cb733eff6d6f09244ea43fc464f7a103b91fdabf4809aea88R202-R203)

### Configuration and Documentation Adjustments
* Added and adjusted several walk speed modifier entries in `docs/carryon-config.md` for specific block types and slots, including new entries for various chest types and crates.
* Updated technical and modding documentation to reflect code changes and new configuration capabilities. [[1]](diffhunk://#diff-c7f905293f3d9f623a219ccc0916fdb7b5e1951eb2acc59ee7d428722ee5a587L171-R174) [[2]](diffhunk://#diff-ff4f69bb7eeef76cb733eff6d6f09244ea43fc464f7a103b91fdabf4809aea88R202-R203) [[3]](diffhunk://#diff-2a29d8f7ec56d7c0b662018999de25f33afdc21cd2d86a77c03df16249604b96L136)

These changes collectively streamline the mod's features, improve configuration flexibility, and keep documentation in sync with code.