### PR TITLE
Feature/hail mary

### DIFF
--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -200,6 +200,7 @@ namespace CarryOn
             EntityBehaviorDropCarriedOnDamage.CarryManager = CarryManager;
             EntityBehaviorDropCarriedOnDamage.Enabled = dropConfig.Enabled;
             EntityBehaviorDropCarriedOnDamage.DamageThreshold = dropConfig.DamageThreshold;
+            EntityBehaviorDropCarriedOnDamage.DropRange = dropConfig.DropRange;
             api.Register<EntityBehaviorDropCarriedOnDamage>();
 
             ServerApi = api;

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -196,6 +196,10 @@ namespace CarryOn
                 return;
             }
 
+            var dropConfig = Config.CarryOptions.DropOnDamage;
+            EntityBehaviorDropCarriedOnDamage.CarryManager = CarryManager;
+            EntityBehaviorDropCarriedOnDamage.Enabled = dropConfig.Enabled;
+            EntityBehaviorDropCarriedOnDamage.DamageThreshold = dropConfig.DamageThreshold;
             api.Register<EntityBehaviorDropCarriedOnDamage>();
 
             ServerApi = api;

--- a/src/Server/Behaviors/EntityBehaviorDropCarriedOnDamage.cs
+++ b/src/Server/Behaviors/EntityBehaviorDropCarriedOnDamage.cs
@@ -13,7 +13,7 @@ namespace CarryOn.Server.Behaviors
 
         public static ICarryManager? CarryManager { get; set; }
         public static bool Enabled { get; set; } = true;
-        public static float DamageThreshold { get; set; } = 0f;
+        public static float DamageThreshold { get; set; } = 1.0f;
         public static int DropRange { get; set; } = 2;
 
         private static readonly CarrySlot[] DropFrom

--- a/src/Server/Behaviors/EntityBehaviorDropCarriedOnDamage.cs
+++ b/src/Server/Behaviors/EntityBehaviorDropCarriedOnDamage.cs
@@ -1,8 +1,8 @@
+using CarryOn.API.Common.Interfaces;
 using CarryOn.API.Common.Models;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using static CarryOn.API.Common.Models.CarryCode;
-using static CarryOn.Utility.Extensions;
 
 namespace CarryOn.Server.Behaviors
 {
@@ -10,6 +10,10 @@ namespace CarryOn.Server.Behaviors
     {
         public static string Name { get; }
             = CarryOnCode("dropondamage");
+
+        public static ICarryManager? CarryManager { get; set; }
+        public static bool Enabled { get; set; } = true;
+        public static float DamageThreshold { get; set; } = 0f;
 
         private static readonly CarrySlot[] DropFrom
             = [CarrySlot.Hands];
@@ -24,8 +28,10 @@ namespace CarryOn.Server.Behaviors
 
         public override void OnEntityReceiveDamage(DamageSource damageSource, ref float damage)
         {
-            if (damageSource.Type != EnumDamageType.Heal)
-                GetCarryManager(entity.Api)?.DropCarried(entity, DropFrom, 2);
+            if (!Enabled) return;
+            if (damageSource.Type == EnumDamageType.Heal) return;
+            if (damage <= DamageThreshold) return;
+            CarryManager?.DropCarried(entity, DropFrom, 2);
         }
     }
 }

--- a/src/Server/Behaviors/EntityBehaviorDropCarriedOnDamage.cs
+++ b/src/Server/Behaviors/EntityBehaviorDropCarriedOnDamage.cs
@@ -14,6 +14,7 @@ namespace CarryOn.Server.Behaviors
         public static ICarryManager? CarryManager { get; set; }
         public static bool Enabled { get; set; } = true;
         public static float DamageThreshold { get; set; } = 0f;
+        public static int DropRange { get; set; } = 2;
 
         private static readonly CarrySlot[] DropFrom
             = [CarrySlot.Hands];
@@ -31,7 +32,7 @@ namespace CarryOn.Server.Behaviors
             if (!Enabled) return;
             if (damageSource.Type == EnumDamageType.Heal) return;
             if (damage <= DamageThreshold) return;
-            CarryManager?.DropCarried(entity, DropFrom, 2);
+            CarryManager?.DropCarried(entity, DropFrom, DropRange);
         }
     }
 }


### PR DESCRIPTION
This pull request updates the logic for dropping carried items when an entity takes damage, making the behavior configurable and improving code maintainability. The main changes include introducing static configuration for the drop-on-damage behavior, integrating these settings during server initialization, and refactoring the damage handling logic.

### Drop-on-damage behavior configuration

* Added static properties (`CarryManager`, `Enabled`, `DamageThreshold`, and `DropRange`) to `EntityBehaviorDropCarriedOnDamage` to allow global configuration of when and how carried items are dropped on damage.
* The drop-on-damage logic now checks these new configuration properties, only triggering a drop if the feature is enabled, the damage type is not healing, and the damage exceeds the threshold. The range for dropping items is also configurable.

### Server initialization integration

* In `CarrySystem.StartServerSide`, the drop-on-damage configuration is loaded from `Config.CarryOptions.DropOnDamage` and applied to the static properties of `EntityBehaviorDropCarriedOnDamage` during server startup.

### Code cleanup

* Removed an unused `using static CarryOn.Utility.Extensions;` directive from `EntityBehaviorDropCarriedOnDamage.cs` for clarity.