### PR TITLE
Feature/prerelease6

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>2.0.0-pre.5</Version>
+		<Version>2.0.0-pre.6</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "2.0.0-pre.5",
+	"version": "2.0.0-pre.6",
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",
 	"authors": [

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -25,7 +25,7 @@ using Newtonsoft.Json;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "2.0.0-pre.5",
+    Version = "2.0.0-pre.6",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]

--- a/src/Client/Logic/CarryRenderer/CarryRenderCache.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderCache.cs
@@ -19,6 +19,7 @@ namespace CarryOn.Client.Logic.CarryRenderer
         public string Signature { get; init; } = null!;
         public CarriedRenderInfo[] RenderInfos { get; init; } = null!;
         public DateTime LastUsedAtUtc { get; set; }
+        public DateTime CreatedAtUtc { get; set; }
     }
 
     internal sealed class SlotCacheState
@@ -34,6 +35,9 @@ namespace CarryOn.Client.Logic.CarryRenderer
         private static readonly TimeSpan TransformPlanCacheTtl = TimeSpan.FromMinutes(5);
         private const int RenderInfoCacheMaxEntries = 512;
         private static readonly TimeSpan RenderInfoCacheTtl = TimeSpan.FromMinutes(3);
+        internal static readonly TimeSpan RenderInfoRebuildTtl = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan RenderInfoEvictionAge = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan TransformPlanEvictionAge = TimeSpan.FromMinutes(5);
 
         internal readonly Dictionary<string, CachedTransformPlan> TransformPlans = new(StringComparer.Ordinal);
         internal readonly Dictionary<string, CachedRenderInfos> RenderInfos = new(StringComparer.Ordinal);
@@ -87,12 +91,16 @@ namespace CarryOn.Client.Logic.CarryRenderer
         }
 
         private void PruneCache<TKey, TValue>(
-            Dictionary<TKey, TValue> dict, int maxEntries, TimeSpan ttl, Func<TValue, DateTime> lastUsedSelector) where TKey : notnull
+            Dictionary<TKey, TValue> dict, int maxEntries, TimeSpan ttl, TimeSpan evictionAge, Func<TValue, DateTime> lastUsedSelector) where TKey : notnull
         {
-            if (dict.Count <= maxEntries) return;
-            var cutoff = DateTime.UtcNow - ttl;
-            var staleKeys = dict.Where(kv => lastUsedSelector(kv.Value) < cutoff).Select(kv => kv.Key).ToList();
+            var ageCutoff = DateTime.UtcNow - evictionAge;
+            var staleKeys = dict.Where(kv => lastUsedSelector(kv.Value) < ageCutoff).Select(kv => kv.Key).ToList();
             foreach (var key in staleKeys) dict.Remove(key);
+
+            if (dict.Count <= maxEntries) return;
+            var ttlCutoff = DateTime.UtcNow - ttl;
+            var expiredKeys = dict.Where(kv => lastUsedSelector(kv.Value) < ttlCutoff).Select(kv => kv.Key).ToList();
+            foreach (var key in expiredKeys) dict.Remove(key);
             if (dict.Count <= maxEntries) return;
             foreach (var key in dict.OrderBy(kv => lastUsedSelector(kv.Value))
                                     .Take(dict.Count - maxEntries)
@@ -103,9 +111,9 @@ namespace CarryOn.Client.Logic.CarryRenderer
         }
         // Usage:
         internal void PruneTransformPlans() =>
-            PruneCache(TransformPlans, TransformPlanCacheMaxEntries, TransformPlanCacheTtl, v => v.LastUsedAtUtc);
+            PruneCache(TransformPlans, TransformPlanCacheMaxEntries, TransformPlanCacheTtl, TransformPlanEvictionAge, v => v.LastUsedAtUtc);
         internal void PruneRenderInfos() =>
-            PruneCache(RenderInfos, RenderInfoCacheMaxEntries, RenderInfoCacheTtl, v => v.LastUsedAtUtc);
+            PruneCache(RenderInfos, RenderInfoCacheMaxEntries, RenderInfoCacheTtl, RenderInfoEvictionAge, v => v.LastUsedAtUtc);
 
     }
 }

--- a/src/Client/Logic/CarryRenderer/CarryRenderCacheManager.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderCacheManager.cs
@@ -64,6 +64,8 @@ namespace CarryOn.Client.Logic.CarryRenderer
         private long lastLoggedRenderInfoBuildCount;
         private DateTime nextDebugCounterLogAtUtc = DateTime.MinValue;
         private static readonly TimeSpan DebugCounterLogInterval = TimeSpan.FromSeconds(5);
+        private DateTime nextPruneAtUtc = DateTime.MinValue;
+        private static readonly TimeSpan PruneInterval = TimeSpan.FromSeconds(10);
 
         public CarriedRenderInfo[] GetRenderInfoCached(EntityAgent entity, CarriedBlock carried, string transformsGroup)
         {
@@ -142,11 +144,18 @@ namespace CarryOn.Client.Logic.CarryRenderer
 
             if (cache.RenderInfos.TryGetValue(renderInfoKey, out var cachedRenderInfos))
             {
-                persistentRenderInfoHitCount++;
-                cachedRenderInfos.LastUsedAtUtc = now;
-                var clonedFromPersistent = CarryRenderHelpers.CloneCarriedRenderInfos(cachedRenderInfos.RenderInfos);
-                cache.FrameRenderInfos[frameKey] = CarryRenderHelpers.CloneCarriedRenderInfos(clonedFromPersistent);
-                return clonedFromPersistent;
+                if (now - cachedRenderInfos.CreatedAtUtc > CarryRenderCache.RenderInfoRebuildTtl)
+                {
+                    cache.RenderInfos.Remove(renderInfoKey);
+                }
+                else
+                {
+                    persistentRenderInfoHitCount++;
+                    cachedRenderInfos.LastUsedAtUtc = now;
+                    var clonedFromPersistent = CarryRenderHelpers.CloneCarriedRenderInfos(cachedRenderInfos.RenderInfos);
+                    cache.FrameRenderInfos[frameKey] = CarryRenderHelpers.CloneCarriedRenderInfos(clonedFromPersistent);
+                    return clonedFromPersistent;
+                }
             }
 
             containerSlots ??= BlockUtils.GetContainerSlots(carriedBlock);
@@ -156,7 +165,8 @@ namespace CarryOn.Client.Logic.CarryRenderer
             {
                 Signature = renderInfoKey,
                 RenderInfos = built,
-                LastUsedAtUtc = now
+                LastUsedAtUtc = now,
+                CreatedAtUtc = now
             };
 
             cache.FrameRenderInfos[frameKey] = built;
@@ -176,6 +186,10 @@ namespace CarryOn.Client.Logic.CarryRenderer
 
         public void PruneCaches()
         {
+            var now = DateTime.UtcNow;
+            if (now < nextPruneAtUtc) return;
+            nextPruneAtUtc = now + PruneInterval;
+
             cache.PruneTransformPlans();
             cache.PruneRenderInfos();
         }

--- a/src/Client/Logic/CarryRenderer/CarryRenderDispatcher.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderDispatcher.cs
@@ -81,6 +81,7 @@ namespace CarryOn.Client.Logic.CarryRenderer
         private object? lastCameraMatrixRef;
         private float[] cachedViewMat = new float[16];
         private static readonly Vec3f ZeroOffset = new(0, 0, 0);
+        private bool disposedDetected;
 
         public void ClearMatrixPool()
         {
@@ -109,6 +110,8 @@ namespace CarryOn.Client.Logic.CarryRenderer
             var allCarried = carryManager.GetAllCarried(entity).ToList();
             if (allCarried.Count == 0) return;
 
+            disposedDetected = false;
+
             var player = api.World.Player;
             var isLocalPlayer = entity == player.Entity;
             var isFirstPerson = isLocalPlayer && (player.CameraMode == EnumCameraMode.FirstPerson);
@@ -124,6 +127,11 @@ namespace CarryOn.Client.Logic.CarryRenderer
                 RenderCarried(entity, carried, deltaTime,
                               isFirstPerson, isImmersiveFirstPerson,
                               stage, isShadowPass, renderer, animator, renderTick);
+            }
+
+            if (disposedDetected)
+            {
+                cacheManager.InvalidateAll();
             }
         }
 
@@ -224,6 +232,12 @@ namespace CarryOn.Client.Logic.CarryRenderer
             foreach (var info in carriedRenderInfo)
             {
                 if (!info.RenderEnabled) continue;
+
+                if (info.RenderInfo.ModelRef == null || info.RenderInfo.ModelRef.Disposed)
+                {
+                    disposedDetected = true;
+                    continue;
+                }
 
                 float[] matrix;
                 bool rentedMatrix = false;
@@ -392,6 +406,13 @@ namespace CarryOn.Client.Logic.CarryRenderer
                     if (!CarryRenderHelpers.ShouldDrawInPhase(d.Phases, translucentPhase)) continue;
 
                     var info = d.Info;
+
+                    if (info.RenderInfo.ModelRef == null || info.RenderInfo.ModelRef.Disposed)
+                    {
+                        disposedDetected = true;
+                        continue;
+                    }
+
                     bool disabledCull = false;
 
                     try

--- a/src/Client/Logic/CarryRenderer/CarryRenderInfoBuilder.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderInfoBuilder.cs
@@ -302,48 +302,13 @@ namespace CarryOn.Client.Logic.CarryRenderer
             }
         }
 
-        private MultiTextureMeshRef? GetOrCreateOwnedMeshRef(ItemStack? stack)
-        {
-            if (stack?.Collectible == null) return null;
-
-            if (stack.Block != null)
-                return GetOrCreateBlockMeshRef(stack.Block);
-
-            if (stack.Item != null)
-                return GetOrCreateItemMeshRef(stack.Item);
-
-            return null;
-        }
-
-        private MultiTextureMeshRef? GetOrCreateItemMeshRef(Item item)
-        {
-            if (ownedMeshCache.TryGetValue(item.Code, out var cached))
-            {
-                return cached;
-            }
-
-            MeshData? meshData = null;
-            try
-            {
-                api.Tesselator.TesselateItem(item, out meshData);
-            }
-            catch
-            {
-                return null;
-            }
-
-            if (meshData == null) return null;
-
-            var meshRef = api.Render.UploadMultiTextureMesh(meshData);
-            ownedMeshCache[item.Code] = meshRef;
-            return meshRef;
-        }
-
         private MultiTextureMeshRef? GetOrCreateBlockMeshRef(Block block)
         {
             if (ownedMeshCache.TryGetValue(block.Code, out var cached))
             {
-                return cached;
+                if (!cached.Disposed)
+                    return cached;
+                ownedMeshCache.Remove(block.Code);
             }
 
             var meshData = api.TesselatorManager.GetDefaultBlockMesh(block);

--- a/src/Client/Logic/CarryRenderer/CarryRenderInfoBuilder.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderInfoBuilder.cs
@@ -14,17 +14,17 @@ namespace CarryOn.Client.Logic.CarryRenderer
 {
     internal sealed class CarryRenderInfoBuilder(ICoreClientAPI api, bool renderAttachedBlocks = true)
     {
-        private readonly Dictionary<AssetLocation, MultiTextureMeshRef> attachedBlockMeshCache = new();
+        private readonly Dictionary<AssetLocation, MultiTextureMeshRef> ownedMeshCache = new();
 
         internal bool RenderAttachedBlocks { get => renderAttachedBlocks; set => renderAttachedBlocks = value; }
 
         public void Dispose()
         {
-            foreach (var meshRef in attachedBlockMeshCache.Values)
+            foreach (var meshRef in ownedMeshCache.Values)
             {
                 meshRef?.Dispose();
             }
-            attachedBlockMeshCache.Clear();
+            ownedMeshCache.Clear();
         }
 
         internal CarriedRenderInfo[] BuildFromPlan(CarriedBlock carried, CachedTransformPlan? plan, TreeAttribute? containerSlots = null)
@@ -302,9 +302,46 @@ namespace CarryOn.Client.Logic.CarryRenderer
             }
         }
 
+        private MultiTextureMeshRef? GetOrCreateOwnedMeshRef(ItemStack? stack)
+        {
+            if (stack?.Collectible == null) return null;
+
+            if (stack.Block != null)
+                return GetOrCreateBlockMeshRef(stack.Block);
+
+            if (stack.Item != null)
+                return GetOrCreateItemMeshRef(stack.Item);
+
+            return null;
+        }
+
+        private MultiTextureMeshRef? GetOrCreateItemMeshRef(Item item)
+        {
+            if (ownedMeshCache.TryGetValue(item.Code, out var cached))
+            {
+                return cached;
+            }
+
+            MeshData? meshData = null;
+            try
+            {
+                api.Tesselator.TesselateItem(item, out meshData);
+            }
+            catch
+            {
+                return null;
+            }
+
+            if (meshData == null) return null;
+
+            var meshRef = api.Render.UploadMultiTextureMesh(meshData);
+            ownedMeshCache[item.Code] = meshRef;
+            return meshRef;
+        }
+
         private MultiTextureMeshRef? GetOrCreateBlockMeshRef(Block block)
         {
-            if (attachedBlockMeshCache.TryGetValue(block.Code, out var cached))
+            if (ownedMeshCache.TryGetValue(block.Code, out var cached))
             {
                 return cached;
             }
@@ -313,7 +350,7 @@ namespace CarryOn.Client.Logic.CarryRenderer
             if (meshData == null) return null;
 
             var meshRef = api.Render.UploadMultiTextureMesh(meshData);
-            attachedBlockMeshCache[block.Code] = meshRef;
+            ownedMeshCache[block.Code] = meshRef;
             return meshRef;
         }
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "modVersion": "2.0.0-pre.5",
+  "modVersion": "2.0.0-pre.6",
   "dependencies": {
     "game": "1.22.0",
     "carryonlib": "1.0.0-pre.5"


### PR DESCRIPTION
This pull request updates the mod version to `2.0.0-pre.6` and introduces several improvements to the carry rendering system, focusing on cache management, resource disposal handling, and mesh reference ownership. The key changes help prevent rendering artifacts or crashes from disposed resources, improve cache eviction logic, and ensure more robust and efficient rendering.

**Cache management and eviction improvements:**

* Enhanced the cache eviction logic in `CarryRenderCache` to use both a time-to-live (TTL) and a hard eviction age, ensuring stale or unused cache entries are removed more reliably. The `PruneCache` method now considers both TTL and eviction age, and new intervals are introduced for pruning and rebuilding render infos (`CarryRenderCache.cs`). [[1]](diffhunk://#diff-7ad2b87c16fece5b9694ab4a02bec55e2084e840df69fbc8a21926dc49ce78b4R38-R40) [[2]](diffhunk://#diff-7ad2b87c16fece5b9694ab4a02bec55e2084e840df69fbc8a21926dc49ce78b4L90-R103) [[3]](diffhunk://#diff-7ad2b87c16fece5b9694ab4a02bec55e2084e840df69fbc8a21926dc49ce78b4L106-R116) [[4]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fR67-R68) [[5]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fR189-R192)
* Added a `CreatedAtUtc` timestamp to `CachedRenderInfos` and logic to forcibly rebuild cached render infos if they are older than a set threshold (`RenderInfoRebuildTtl`), ensuring outdated render data is not reused (`CarryRenderCache.cs`, `CarryRenderCacheManager.cs`). [[1]](diffhunk://#diff-7ad2b87c16fece5b9694ab4a02bec55e2084e840df69fbc8a21926dc49ce78b4R22) [[2]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fR146-R159) [[3]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fL159-R169)

**Resource disposal and rendering robustness:**

* Added detection for disposed mesh references during rendering in `CarryRenderDispatcher`. If a disposed mesh is detected, the cache is invalidated to prevent rendering issues, and rendering for that mesh is skipped. This is handled in both the main render and shadow pass methods. [[1]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548R84) [[2]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548R113-R114) [[3]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548R131-R135) [[4]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548R236-R241) [[5]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548R409-R415)

**Mesh reference ownership and caching:**

* Refactored `CarryRenderInfoBuilder` to use a unified `ownedMeshCache` for both block and item mesh references, ensuring all uploaded meshes are tracked and disposed properly. Added a new method to handle item mesh reference creation and caching. [[1]](diffhunk://#diff-b262ad46566b5768865b63fb4c7a38958d02f2ecd9d40832cf37641b2da3e695L17-R27) [[2]](diffhunk://#diff-b262ad46566b5768865b63fb4c7a38958d02f2ecd9d40832cf37641b2da3e695R305-R344) [[3]](diffhunk://#diff-b262ad46566b5768865b63fb4c7a38958d02f2ecd9d40832cf37641b2da3e695L316-R353)

**Version updates:**

* Bumped the mod version to `2.0.0-pre.6` in `CarryOn.csproj`, `modinfo.json`, and `version.json` to reflect the new release. [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[3]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L28-R28) [[4]](diffhunk://#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL2-R2)

These changes collectively improve the stability and maintainability of the carry rendering system, reducing the risk of crashes due to disposed resources and ensuring caches remain fresh and efficient.