### PR TITLE
Feature/prerelease7

### DIFF
--- a/CarryOn.csproj
+++ b/CarryOn.csproj
@@ -3,7 +3,7 @@
 		
 		<AssemblyTitle>Carry On</AssemblyTitle>
 		<Authors>copygirl,NerdScurvy</Authors>
-		<Version>2.0.0-pre.6</Version>
+		<Version>2.0.0-pre.7</Version>
 		
 		<Description>Vintage Story mod which adds the capability to carry various things</Description>
 		<RepositoryUrl>https://github.com/NerdScurvy/CarryOn</RepositoryUrl>

--- a/docs/carryon-config.md
+++ b/docs/carryon-config.md
@@ -138,7 +138,6 @@ When `HandsEnabled`/`BackEnabled` is `false`, the walk speed penalty for that sl
     { "Key": "BlockCrate", "Hands": -0.80 }
   ],
   "SlotDefaults": {
-    "Key": null,
     "Hands": -0.25,
     "Back": -0.15
   }

--- a/resources/assets/carryon/patches/carryonmore/chiseltools.json
+++ b/resources/assets/carryon/patches/carryonmore/chiseltools.json
@@ -643,11 +643,10 @@
 		"file": "chiseltools:blocktypes/chiseledsign",
 		"side": "Server",
 		"op": "add",
-		"path": "/behaviors",
-		"value": [
-			{
-				"name": "Carryable",
-				"properties": {
+		"path": "/behaviors/-",
+		"value": {
+			"name": "Carryable",
+			"properties": {
 					"enabledCondition": "carryon.Carryables.Sign",
 					"labelRenderSettings": {
 						"maxWidth": 100,
@@ -680,8 +679,7 @@
 					},
 					"preventAttaching": true
 				}
-			}
-		],
+			},
 		"dependsOn": [
 			{
 				"modid": "chiseltools"

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Carry On",
 	"modid": "carryon",
-	"version": "2.0.0-pre.6",
+	"version": "2.0.0-pre.7",
 	"description": "Adds the capability to carry various things",
 	"website": "https://github.com/NerdScurvy/CarryOn",
 	"authors": [
@@ -11,6 +11,6 @@
 	],
 	"dependencies": {
 		"game": "1.22.0",
-		"carryonlib": "1.0.0-pre.5"
+		"carryonlib": "1.0.0-pre.7"
 	}
 }

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -18,6 +18,7 @@ using CarryOn.Server.Logic;
 using CarryOn.Utility;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
 using Vintagestory.API.Server;
 using static CarryOn.API.Common.Models.CarryCode;
 using CarryOn.Common.Entities;
@@ -25,12 +26,12 @@ using Newtonsoft.Json;
 
 [assembly: ModInfo("Carry On",
     modID: "carryon",
-    Version = "2.0.0-pre.6",
+    Version = "2.0.0-pre.7",
     Description = "Adds the capability to carry various things",
     Website = "https://github.com/NerdScurvy/CarryOn",
     Authors = new[] { "copygirl", "NerdScurvy" })]
 [assembly: ModDependency("game", "1.22.0")]
-[assembly: ModDependency("carryonlib", "1.0.0-pre.5")]
+[assembly: ModDependency("carryonlib", "1.0.0-pre.7")]
 
 namespace CarryOn
 {
@@ -156,8 +157,8 @@ namespace CarryOn
             ConfigService.OnConfigChanged += _ =>
             {
                 if (ServerApi == null) return;
-                var tree = ServerApi.World.Config?.GetOrAddTreeAttribute(ModId);
-                tree?.MergeTree(Config.ToTreeAttribute());
+                if (ServerApi.World.Config is TreeAttribute worldTree)
+                    worldTree[ModId] = Config.ToTreeAttribute();
                 ServerApi.StoreModConfig(Config, ConfigFile);
             };
             ConfigService.OnConfigChanged += _ =>

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -157,7 +157,7 @@ namespace CarryOn
             ConfigService.OnConfigChanged += _ =>
             {
                 if (ServerApi == null) return;
-                if (ServerApi.World.Config is TreeAttribute worldTree)
+                if (ServerApi.World.Config is ITreeAttribute worldTree)
                     worldTree[ModId] = Config.ToTreeAttribute();
                 ServerApi.StoreModConfig(Config, ConfigFile);
             };

--- a/src/Common/Logic/TransferLogic.cs
+++ b/src/Common/Logic/TransferLogic.cs
@@ -112,8 +112,6 @@ namespace CarryOn.Common.Logic
             var carriedHands = player?.Entity != null ? carryManager.GetCarried(player.Entity, CarrySlot.Hands) : null;
             if (carriedHands == null) return false;
 
-            if (carriedHands.BlockEntityData == null) return false;
-
             try
             {
                 return transferHandler.CanPutCarryable(player!, blockEntity, index, carriedHands.ItemStack, carriedHands.BlockEntityData,
@@ -239,8 +237,6 @@ namespace CarryOn.Common.Logic
             if (!TryResolveTransferTarget(blockPos, methodName, out var blockEntity, out _, out var transferHandler, out failureCode, out onScreenErrorMessage))
                 return false;
 
-            if (carriedHands.BlockEntityData == null) return false;
-
             try
             {
                 var success = transferHandler!.TryPutCarryable(player, blockEntity, message.Index, carriedHands.ItemStack, carriedHands.BlockEntityData,
@@ -286,7 +282,7 @@ namespace CarryOn.Common.Logic
                 return false;
 
             ItemStack itemStack;
-            ITreeAttribute blockEntityData;
+            ITreeAttribute? blockEntityData;
             try
             {
                 var success = transferHandler!.TryTakeCarryable(player, blockEntity, message.Index, out itemStack, out blockEntityData,

--- a/src/Server/Logic/ModConfig.cs
+++ b/src/Server/Logic/ModConfig.cs
@@ -45,12 +45,16 @@ namespace CarryOn.Server.Logic
             }
 
             // Cleanup old world config: Remove all keys starting with "carryon:"
+            // and the ModId tree itself so stale entries from previous sessions
+            // are cleared. MergeTree does not delete absent keys, so without
+            // removing the tree first, old override entries would persist forever.
             if (worldConfig is TreeAttribute tree)
             {
                 var keysToRemove = new List<string>();
                 foreach (var key in tree.Keys)
                 {
-                    if (key.StartsWith(CarryCode.WorldConfigPrefix, StringComparison.OrdinalIgnoreCase))
+                    if (key.StartsWith(CarryCode.WorldConfigPrefix, StringComparison.OrdinalIgnoreCase)
+                        || key == ModId)
                         keysToRemove.Add(key);
                 }
                 foreach (var key in keysToRemove)

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
-  "modVersion": "2.0.0-pre.6",
+  "modVersion": "2.0.0-pre.7",
   "dependencies": {
     "game": "1.22.0",
-    "carryonlib": "1.0.0-pre.5"
+    "carryonlib": "1.0.0-pre.7"
   }
 }


### PR DESCRIPTION
This pull request updates the Carry On mod to version 2.0.0-pre.7 and makes several improvements and fixes related to configuration handling, dependency versions, and patch structure. The most important changes are summarized below:

**Version and Dependency Updates:**

* Bumped the mod version to `2.0.0-pre.7` in `CarryOn.csproj`, `resources/modinfo.json`, and `version.json`, and updated the dependency on `carryonlib` to `1.0.0-pre.7` throughout the project. [[1]](diffhunk://#diff-5b6093ada8df2e04821a8264643e6d2757a7ad680b9e885d10bd5532a6fcaed8L6-R6) [[2]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L5-R5) [[3]](diffhunk://#diff-72185534b39456dc67b49f38af48686100c5f8b000a31f39e4c7dafb20fdc4f5L14-R14) [[4]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750R21-R34) [[5]](diffhunk://#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL2-R5)

**Configuration Handling Improvements:**

* Improved the way configuration changes are applied on the server: now replaces the entire mod config tree in `WireConfigChangeHandlers` instead of merging, ensuring stale entries are cleared.
* Enhanced cleanup of old world config in `ModConfig.cs` by removing the entire mod config tree (`ModId`) in addition to keys starting with the prefix, preventing persistence of obsolete override entries.

**Patch Structure Fixes:**

* Fixed the JSON patch structure for chiseltools carryable behavior by switching from adding an array to adding a single object at the correct path in `chiseltools.json`. [[1]](diffhunk://#diff-20ef7202a422ce74586d80c031ed2a15edb041681b24e7bff31e3a5ef464e37eL646-R647) [[2]](diffhunk://#diff-20ef7202a422ce74586d80c031ed2a15edb041681b24e7bff31e3a5ef464e37eL683-R682)

**Code Robustness and Documentation:**

* Removed unnecessary null checks for `BlockEntityData` in transfer logic, as these are now handled elsewhere, and updated type annotations for clarity. [[1]](diffhunk://#diff-d13014c36dc881dfcc92fa03901edefcbce0067a029171b7bfa589b62268302fL115-L116) [[2]](diffhunk://#diff-d13014c36dc881dfcc92fa03901edefcbce0067a029171b7bfa589b62268302fL242-L243) [[3]](diffhunk://#diff-d13014c36dc881dfcc92fa03901edefcbce0067a029171b7bfa589b62268302fL289-R285)
* Minor documentation fix in `carryon-config.md` by removing an unused `"Key": null` entry from the example.