### PR TITLE
Feature/prerelease8 fix

### DIFF
--- a/docs/technical-overview/config-initialization-and-flow.md
+++ b/docs/technical-overview/config-initialization-and-flow.md
@@ -21,102 +21,164 @@ Minimal interface. Two implementers:
 | Implementer | File | Behavior |
 |---|---|---|
 | `CarrySystem` | `src/CarrySystem.cs:42` | Returns `ConfigService.Config` |
-| `CarryManager` | `src/Common/Services/CarryManager.cs:21` | Delegates to its stored `IConfigProvider` |
+| `CarryManager` | `src/Common/Services/CarryManager.cs:21` | Delegates to its stored `IConfigProvider` (`CarrySystem`) |
+
+### Config Access Pattern
+
+`ICarryManager` (in CarryOnLib) cannot expose `CarryOnConfig` directly —
+the config type is too volatile for the API library. Consumers that need
+config hold `ICarryManager` and cast to `IConfigProvider` once in their
+constructor:
+
+```csharp
+this.configProvider = (IConfigProvider)carryManager
+    ?? throw new ArgumentException("carryManager must implement IConfigProvider", ...);
+```
+
+This cast is safe: `CarryManager` is the only `ICarryManager` implementation
+and always implements both interfaces. The cast fires once per instance and
+has zero hot-path cost.
+
+**4 consumers use this pattern:**
+- `CarryHandler` (`src/Common/Handlers/CarryHandler.cs`)
+- `CarryInteractionValidator` (`src/Client/Logic/Interaction/`)
+- `CarryRenderCacheManager` (`src/Client/Logic/CarryRenderer/`)
+- `CarryRenderDispatcher` (`src/Client/Logic/CarryRenderer/`)
 
 ---
 
 ## 2. Initialization Sequence
 
-### 2a. Config File Loading (Server side only)
+### 2a. Server Startup (`StartPre`)
 
+```mermaid
+flowchart TD
+    disk["CarryOnConfig.json<br>&lt;VintagestoryData&gt;/ModConfig"]
+    load["ModConfig.Load(ICoreServerAPI)"]
+    upgrade["UpgradeVersion()"]
+    worldTree["World Config Tree<br>api.World.Config['carryon']"]
+    store["api.StoreModConfig()"]
+    configService["CarryOnConfigService(config)"]
+    clientSync["VS network syncs world tree<br>to connected clients"]
+
+    disk -->|LoadModConfig| load
+    load -->|null? use defaults| upgrade
+    upgrade --> configService
+    upgrade --> store
+    upgrade --> worldTree
+    worldTree --> clientSync
 ```
-CarrySystem.StartPre()
-  └─ ICoreServerAPI only:
-       new ModConfig().Load(api)
-         ├─ api.LoadModConfig<CarryOnConfig>("CarryOnConfig.json")
-         │    └─ reads from <VintagestoryData>/ModConfig/CarryOnConfig.json
-         ├─ if null ⇒ new CarryOnConfig(CurrentConfigVersion)  // defaults
-         ├─ UpgradeVersion()  // migrates v1→2→3→4
-         ├─ api.StoreModConfig(config, "CarryOnConfig.json")
-         └─ world config tree:
-              api.World.Config
-                .GetOrAddTreeAttribute("carryon")
-                .MergeTree(config.ToTreeAttribute())
+
+**`ModConfig.Load(ICoreServerAPI)`** returns `CarryOnConfig?`:
+
+```csharp
+// src/Server/Logic/ModConfig.cs
+public CarryOnConfig? Load(ICoreServerAPI api)
+{
+    var config = api.LoadModConfig<CarryOnConfig>(ConfigFile)
+                 ?? new CarryOnConfig(CurrentConfigVersion);
+    config.UpgradeVersion();
+    api.StoreModConfig(config, ConfigFile);
+    // write to world config tree (needed for client sync)
+    var worldTree = api.World.Config.GetOrAddTreeAttribute("carryon");
+    worldTree.MergeTree(config.ToTreeAttribute());
+    return config;   // caller uses this directly
+}
 ```
 
-`ModConfig.Load()` serializes the config into the world's `ITreeAttribute` storage.
-This is how the config survives world reloads and syncs to clients.
+### 2b. Client Startup (`StartPre`)
 
-### 2b. Config Deserialization (Both Sides)
+```mermaid
+flowchart TD
+    worldTree["World Config Tree<br>(synced by VS network layer)"]
+    fromTree["CarryOnConfig.FromTreeAttribute(tree)"]
+    defaults["new CarryOnConfig()"]
+    configService["CarryOnConfigService(config)"]
 
-After `ModConfig.Load()` has written the world config tree, `CarrySystem.StartPre()`
-reads it back:
-
-```
-CarrySystem.StartPre()
-  ├─ Api.Side == server:
-  │    ModConfig.Load(api)          // loads file → world config tree
-  │
-  ├─ Api.Side == client:
-  │    (world config tree already synced by VS network layer)
-  │
-  ├─ config = api.World.Config["carryon"] is ITreeAttribute tree
-  │    ? CarryOnConfig.FromTreeAttribute(tree)   // deserialize from tree
-  │    : new CarryOnConfig()                     // fallback defaults
-  │
-  └─ ConfigService = new CarryOnConfigService(config)
+    worldTree -->|tree exists| fromTree
+    worldTree -->|no tree| defaults
+    fromTree --> configService
+    defaults --> configService
 ```
 
 The **client** never reads `CarryOnConfig.json` from disk. It receives the config
-via the server's world config sync or via the `ConfigSyncMessage` network packet.
+via the server's world config sync (VS built-in) or via the `ConfigSyncMessage`
+network packet (for hot-reload).
 
-### 2c. Config Distribution
+### 2c. Server + Client Combined (`StartPre`)
 
-In `CarrySystem.Start()`:
+```csharp
+// src/CarrySystem.cs
+CarryOnConfig config;
 
+if (api is ICoreServerAPI sapi)
+{
+    config = new ModConfig().Load(sapi) ?? new CarryOnConfig();
+}
+else
+{
+    var tree = api.World.Config?.GetTreeAttribute(ModId);
+    config = tree != null
+        ? CarryOnConfig.FromTreeAttribute(tree)
+        : new CarryOnConfig();
+}
+
+ConfigService = new CarryOnConfigService(config);
 ```
-CarrySystem.Start()
-  ├─ CarryManager = new CarryManager(api, this, CarryEvents)
-  │    └─ this (CarrySystem) is passed as IConfigProvider
-  │    └─ CarryManager.Config ⇒ ConfigProvider.Config ⇒ CarrySystem.Config ⇒ ConfigService.Config
-  │
-  ├─ CarryHandler = new CarryHandler(carryManager, this.Config, ...)
-  │    └─ stores private copy of config (mutable, updated via UpdateConfig())
-  │
-  ├─ (client only) EntityCarryRenderer = new(api, carryManager, this.Config, ...)
-  │    └─ stores private copy, passes to CacheManager & Dispatcher
-  │
-  └─ WireConfigChangeHandlers()
-       └─ subscribes to ConfigService.OnConfigChanged
+
+**Key improvement over the old architecture:** The server no longer performs a
+redundant deserialization round-trip. `ModConfig.Load()` returns the loaded
+config directly. The world config tree is still written (for client sync), but
+the server doesn't read it back.
+
+### 2d. Distribution (`Start`)
+
+```mermaid
+flowchart TD
+    cfgService["CarryOnConfigService"]
+    cs["CarrySystem (IConfigProvider)<br>Config ⇒ ConfigService.Config"]
+    cm["CarryManager<br>(receives CarrySystem as IConfigProvider)"]
+    ch["CarryHandler<br>reads via configProvider.Config"]
+    er["EntityCarryRenderer<br>reads via child renderers"]
+    wired["WireConfigChangeHandlers()"]
+
+    cs -->|"new CarryManager(api, this, ...)"| cm
+    cs -->|"new CarryHandler(carryManager, ...)"| ch
+    cs -->|"new EntityCarryRenderer(api, carryManager, ...)"| er
+    cs --> wired
+
+    cm -.->|cast to IConfigProvider| ch
+    cm -.->|cast to IConfigProvider| er
 ```
+
+No consumer stores a private `CarryOnConfig` copy. All read live from
+`carryManager` via the cast-to-`IConfigProvider` pattern.
 
 ---
 
 ## 3. Config Consumer Chain
 
-```
-CarrySystem (IConfigProvider)
-  │
-  ├── Config property ⇒ ConfigService.Config
-  │
-  ├── AS IConfigProvider → CarryManager constructor
-  │    └── CarryManager.Config (delegates to IConfigProvider.Config)
-  │
-  ├── AS CarryOnConfig (value copy) → CarryHandler
-  │    └── → CarryInteractionController (via InitClient)
-  │         └── → CarryInteractionValidator
-  │              └── Invalidates parsed arrays (PreventSwapFromBackOnTarget)
-  │
-  ├── AS CarryOnConfig (value copy) → EntityCarryRenderer
-  │    └── → CarryRenderCacheManager
-  │    └── → CarryRenderDispatcher
-  │
-  └── AS CarryOnConfig (value copy) → BehavioralConditioning.Init(api, config)
-       └── One-shot at AssetsFinalize (not wired to reload)
+```mermaid
+flowchart LR
+    cs["CarrySystem<br>(IConfigProvider)"]
+    cs -->|Config| csc["ConfigService.Config"]
+    cs -->|as IConfigProvider| cm["CarryManager.Config"]
+    cm -->|cast to IConfigProvider| ch["CarryHandler"]
+    cm -->|cast to IConfigProvider| cv["CarryInteractionValidator"]
+    cm -->|cast to IConfigProvider| rcm["CarryRenderCacheManager"]
+    cm -->|cast to IConfigProvider| rd["CarryRenderDispatcher"]
+    cs -->|direct| bc["BehavioralConditioning<br>(one-shot, not wired to reload)"]
+    cs -->|direct| ecb["EntityCarriedBlock.Config<br>(static, pushed on change)"]
 ```
 
-Every consumer stores a **private mutable field** for config, then relies on
-`UpdateConfig()` to receive new instances on change.
+| Consumer | Access Path | Reacts to Change? |
+|---|---|---|
+| `CarryHandler` | `configProvider.Config.X` | Yes — relays to `RefreshConfigCache()` |
+| `CarryInteractionValidator` | `configProvider.Config.X` | Yes — re-parses `PreventSwapFromBackOnTarget` |
+| `CarryRenderCacheManager` | `configProvider.Config.X` | No — reads live each render tick |
+| `CarryRenderDispatcher` | `configProvider.Config.X` | No — reads live each render tick |
+| `EntityCarriedBlock` (static) | Pushed via subscriber | Yes — `Config = Config.CarriedBlockEntity` |
+| `BehavioralConditioning` | Direct `CarryOnConfig` param | No — one-shot at `AssetsFinalize` |
 
 ---
 
@@ -136,17 +198,20 @@ Every consumer stores a **private mutable field** for config, then relies on
 `CarryOnConfigService.SetupFileWatcher(ICoreServerAPI)` creates a
 `FileSystemWatcher` on `<VintagestoryData>/ModConfig/CarryOnConfig.json`:
 
-```
-FileSystemWatcher.Changed / .Created
-  └─ OnConfigFileChanged()
-       ├─ debounce 500ms (prevents double-fire)
-       ├─ Thread.Sleep(100)  (let file IO settle)
-       └─ api.Event.EnqueueMainThreadTask(ReloadFromFile)
-            ├─ api.LoadModConfig<CarryOnConfig>(ConfigFile)
-            ├─ reloaded.UpgradeVersion()
-            └─ Replace(reloaded)
-                 ├─ Config = newConfig
-                 └─ OnConfigChanged?.Invoke(newConfig)
+```mermaid
+flowchart TD
+    fs["FileSystemWatcher<br>.Changed / .Created"]
+    debounce["Debounce 500ms<br>Thread.Sleep(100)"]
+    mainThread["EnqueueMainThreadTask<br>(ReloadFromFile)"]
+    load["api.LoadModConfig<br>&lt;CarryOnConfig&gt;"]
+    upgrade["UpgradeVersion()"]
+    replace["Replace(reloaded)<br>Config = newConfig<br>OnConfigChanged?.Invoke(newConfig)"]
+
+    fs --> debounce
+    debounce --> mainThread
+    mainThread --> load
+    load --> upgrade
+    upgrade --> replace
 ```
 
 Disabled when `DebuggingOptions.DisableConfigWatcher` is `true`.
@@ -171,113 +236,108 @@ All in `CarrySystem.Start()`:
 | Order | Subscriber | Effect |
 |---|---|---|
 | 1 | `Config.InvalidateBackpackCache()` | Clears lazy-parsed `BackpackMapping` dictionary |
-| 2 | `CarryHandler?.UpdateConfig(cfg)` | Updates private config; forwards to `InteractionController` → `Validator` → `InvalidateConfigCache()` (re-parses `PreventSwapFromBackOnTarget` filters) |
-| 3 | `EntityCarryRenderer?.UpdateConfig(cfg)` | Updates private config; forwards to `CacheManager.UpdateConfig()`, `Dispatcher.UpdateConfig()` |
-| 4 | `EntityCarriedBlock.Config = Config.CarriedBlockEntity` | Carried block entity behavior settings |
-| 5 | (server) persist to world config + disk | `ServerApi.StoreModConfig(Config, ConfigFile)` |
-| 6 | (server) broadcast to clients | `ServerChannel.BroadcastPacket(new ConfigSyncMessage(json))` |
+| 2 | `CarryHandler?.RefreshConfigCache()` | Forwards to `InteractionController` → `Validator` → re-parses `PreventSwapFromBackOnTarget` filters |
+| 3 | `EntityCarriedBlock.Config = Config.CarriedBlockEntity` | Carried block entity behavior settings |
+| 4 | (server) persist to world config + disk | `ServerApi.StoreModConfig(Config, ConfigFile)` |
+| 5 | (server) broadcast to clients | `ServerChannel.BroadcastPacket(new ConfigSyncMessage(json))` |
+
+No more forwarding to 6+ individual `UpdateConfig()` methods. Consumers
+read config live from `carryManager` — they don't need to be pushed a copy.
 
 ### 4e. Network Sync
 
-```
-Server (OnConfigChanged):
-  ├─ json = JsonConvert.SerializeObject(Config)
-  └─ ServerChannel.BroadcastPacket(new ConfigSyncMessage(json))
-
-Client (CarrySystem.OnClientConfigSync):
-  ├─ var reloaded = JsonConvert.DeserializeObject<CarryOnConfig>(message.ConfigJson)
-  ├─ reloaded.UpgradeVersion()
-  └─ ConfigService.Replace(reloaded)
-       └─ fires OnConfigChanged (subscribers 1-4 above run client-side)
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Clients
+    Server->>Server: ConfigService.Replace(newConfig)
+    Server->>Server: OnConfigChanged fired
+    Server->>Server: JsonConvert.SerializeObject(Config)
+    Server->>Clients: BroadcastPacket(ConfigSyncMessage(json))
+    Clients->>Clients: OnClientConfigSync(message)
+    Clients->>Clients: Deserialize + UpgradeVersion
+    Clients->>Clients: ConfigService.Replace(reloaded)
+    Clients->>Clients: OnConfigChanged fired (client subscribers)
 ```
 
 ---
 
-## 5. Flow Diagram
+## 5. Full Flow Diagram
 
-```
-                          ┌──────────────────────────────┐
-                          │       CarryOnConfig.json      │
-                          │  <VintagestoryData>/ModConfig │
-                          └──────────────┬───────────────┘
-                                         │
-                          ┌──────────────▼───────────────┐
-                          │  ModConfig.Load(api)         │
-                          │  (server StartPre)           │
-                          │  • LoadModConfig             │
-                          │  • UpgradeVersion            │
-                          │  • StoreModConfig            │
-                          │  • worldConfig.MergeTree()   │
-                          └──────────────┬───────────────┘
-                                         │ (via world config ITreeAttribute)
-                          ┌──────────────▼───────────────┐
-                          │  CarryOnConfig.FromTreeAttr()│
-                          │  (both sides, StartPre)      │
-                          └──────────────┬───────────────┘
-                                         │
-                          ┌──────────────▼───────────────┐
-                          │  CarryOnConfigService(config) │
-                          │  • Config property            │
-                          │  • OnConfigChanged event      │
-                          │  • Replace() / Reload()       │
-                          │  • SetupFileWatcher()         │
-                          └──────┬───────────────────────┘
-                                 │
-                    ┌────────────┼────────────────────────────┐
-                    │            │                            │
-         ┌──────────▼────┐ ┌────▼──────────┐     ┌───────────▼──────────┐
-         │  CarrySystem   │ │ CarryHandler  │     │ EntityCarryRenderer  │
-         │  (IConfigPro-  │ │ (private copy)│     │ (private copy)       │
-         │   vider)       │ │              │     │                      │
-         │  Config ⇒      │ │ UpdateConfig │     │ UpdateConfig         │
-         │  ConfigService │ │   ↓           │     │   ↓                  │
-         │                │ │ Interaction   │     ├─ CacheManager        │
-         │  Passed as     │ │ Controller    │     └─ Dispatcher         │
-         │  IConfigProv.  │ │   ↓           │                          │
-         │  → CarryManager│ │ Validator     │                          │
-         └────────────────┘ └──────────────┘     └──────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Startup["Startup Sequence"]
+        disk["CarryOnConfig.json"]
+        sapi["ICoreServerAPI"]
+        modcfg["ModConfig.Load(sapi)"]
+        upgrade["UpgradeVersion()"]
+        worldtree["World Config Tree"]
+        store["StoreModConfig"]
+        csc["CarryOnConfigService(config)"]
+    end
 
-                     HOT RELOAD FLOW (server):
+    subgraph Distribution["Config Distribution"]
+        cs["CarrySystem<br>(IConfigProvider)"]
+        cm["CarryManager<br>(delegates to IConfigProvider)"]
+        ch["CarryHandler<br>(reads via IConfigProvider cast)"]
+        cv["Validator<br>(reads via IConfigProvider cast)"]
+        rcm["CacheManager<br>(reads via IConfigProvider cast)"]
+        rd["Dispatcher<br>(reads via IConfigProvider cast)"]
+        ecb["EntityCarriedBlock.Config<br>(static push)"]
+    end
 
-  Disk change ──► FileWatcher ──► ReloadFromFile()
-                                    │
-                                    ▼
-  /carryon reload ─────────────► Reload() ──► Replace(newConfig)
-                                    │
-                                    ▼
-                            OnConfigChanged
-                                    │
-              ┌─────────────────────┼──────────────────────┐
-              ▼                     ▼                      ▼
-      InvalidateBackpack     Update Consumers        Broadcast to
-              │              (Handler, Renderer,     Clients via
-              │               EntityCarriedBlock)    ConfigSyncMessage
-              │                                         │
-              ▼                                         ▼
-      BackpackMapping                              Client Dispatches
-      recalculated on                              OnClientConfigSync
-      next access                                         │
-                                                          ▼
-                                                   ConfigService.Replace()
-                                                          │
-                                                          ▼
-                                                   OnConfigChanged
-                                                   (client-side subscribers)
+    subgraph HotReload["Hot Reload"]
+        fw["FileSystemWatcher"]
+        reload["ReloadFromFile()"]
+        replace["Replace(newConfig)"]
+        evt["OnConfigChanged"]
+        inv_bp["InvalidateBackpackCache"]
+        inv_v["RefreshConfigCache"]
+        push_ecb["EntityCarriedBlock.Config = ..."]
+        persist["Persist world tree + disk"]
+        broadcast["Broadcast ConfigSyncMessage"]
+    end
+
+    disk --> modcfg
+    sapi --> modcfg
+    modcfg --> upgrade
+    upgrade --> worldtree
+    upgrade --> store
+    upgrade --> csc
+
+    csc --> cs
+    cs --> cm
+    cm --> ch
+    cm --> cv
+    cm --> rcm
+    cm --> rd
+    cs --> ecb
+
+    fw --> reload --> replace --> evt
+    evt --> inv_bp
+    evt --> inv_v
+    evt --> push_ecb
+    evt --> persist
+    evt --> broadcast
 ```
 
 ---
 
 ## 6. Key Design Points
 
-- **ConfigService is the single source of truth.** `CarrySystem.Config` delegates
+- **`ConfigService` is the single source of truth.** `CarrySystem.Config` delegates
   to it. `CarryManager.Config` delegates through `CarrySystem` via `IConfigProvider`.
-- **Private mutable copies.** Most consumers take a config snapshot at construction
-  and rely on `UpdateConfig()` for hot-reload. This avoids coupling to the service
-  lifecycle and makes testing simpler.
+- **No private copies.** All consumers read config live from `carryManager` via the
+  `IConfigProvider` cast. `UpdateConfig()` no longer exists.
 - **Server-authoritative.** Only the server can trigger hot-reload from disk.
   Clients receive the config as a serialized JSON message.
-- **Two serializations at startup.** `ModConfig.Load()` writes POCO → `ITreeAttribute`
-  (world config), then `StartPre()` reads `ITreeAttribute` → POCO. This ensures
-  the config is always consistent with world storage.
+- **One serialization at startup.** `ModConfig.Load()` returns the loaded config
+  directly. The server no longer reads it back from the world config tree. The
+  world tree is still written (for client sync), but only the client deserializes
+  from it.
 - **`BehavioralConditioning` is NOT wired to hot-reload.** It runs once at
   `AssetsFinalize`. Carryables, interactables, and filter changes require restart.
+- **The cast pattern is a deliberate trade-off.** `ICarryManager` (CarryOnLib)
+  can't reference the volatile `CarryOnConfig` type. The runtime cast to
+  `IConfigProvider` is safe (`CarryManager` always implements both) and has
+  zero hot-path cost. Four consumers use it.

--- a/docs/technical-overview/config-initialization-and-flow.md
+++ b/docs/technical-overview/config-initialization-and-flow.md
@@ -31,7 +31,7 @@ config hold `ICarryManager` and cast to `IConfigProvider` once in their
 constructor:
 
 ```csharp
-this.configProvider = (IConfigProvider)carryManager
+this.configProvider = carryManager as IConfigProvider
     ?? throw new ArgumentException("carryManager must implement IConfigProvider", ...);
 ```
 
@@ -39,11 +39,14 @@ This cast is safe: `CarryManager` is the only `ICarryManager` implementation
 and always implements both interfaces. The cast fires once per instance and
 has zero hot-path cost.
 
-**4 consumers use this pattern:**
+**7 consumers use this pattern:**
 - `CarryHandler` (`src/Common/Handlers/CarryHandler.cs`)
 - `CarryInteractionValidator` (`src/Client/Logic/Interaction/`)
 - `CarryRenderCacheManager` (`src/Client/Logic/CarryRenderer/`)
 - `CarryRenderDispatcher` (`src/Client/Logic/CarryRenderer/`)
+- `TooHotToPickup` (`src/Events/TooHotToPickup.cs`)
+- `DroppedBlockTracker` (`src/Events/DroppedBlockTracker.cs`)
+- `CarryableInteractionHelpBuilder` (`src/Common/Logic/CarryableInteractionHelpBuilder.cs`)
 
 ---
 
@@ -54,7 +57,7 @@ has zero hot-path cost.
 ```mermaid
 flowchart TD
     disk["CarryOnConfig.json<br>&lt;VintagestoryData&gt;/ModConfig"]
-    load["ModConfig.Load(ICoreServerAPI)"]
+    load["ModConfig.Load(ICoreAPI)"]
     upgrade["UpgradeVersion()"]
     worldTree["World Config Tree<br>api.World.Config['carryon']"]
     store["api.StoreModConfig()"]
@@ -69,11 +72,11 @@ flowchart TD
     worldTree --> clientSync
 ```
 
-**`ModConfig.Load(ICoreServerAPI)`** returns `CarryOnConfig?`:
+**`ModConfig.Load(ICoreAPI)`** returns `CarryOnConfig?`:
 
 ```csharp
 // src/Server/Logic/ModConfig.cs
-public CarryOnConfig? Load(ICoreServerAPI api)
+public CarryOnConfig? Load(ICoreAPI api)
 {
     var config = api.LoadModConfig<CarryOnConfig>(ConfigFile)
                  ?? new CarryOnConfig(CurrentConfigVersion);

--- a/docs/technical-overview/config-initialization-and-flow.md
+++ b/docs/technical-overview/config-initialization-and-flow.md
@@ -1,0 +1,283 @@
+# Config Initialization and Flow
+
+This document traces how `CarryOnConfig` is created, distributed, and hot-reloaded
+through the system — from disk to every consumer.
+
+---
+
+## 1. Interface: `IConfigProvider`
+
+**File:** `src/Common/Interfaces/IConfigProvider.cs`
+
+```csharp
+public interface IConfigProvider
+{
+    CarryOnConfig Config { get; }
+}
+```
+
+Minimal interface. Two implementers:
+
+| Implementer | File | Behavior |
+|---|---|---|
+| `CarrySystem` | `src/CarrySystem.cs:42` | Returns `ConfigService.Config` |
+| `CarryManager` | `src/Common/Services/CarryManager.cs:21` | Delegates to its stored `IConfigProvider` |
+
+---
+
+## 2. Initialization Sequence
+
+### 2a. Config File Loading (Server side only)
+
+```
+CarrySystem.StartPre()
+  └─ ICoreServerAPI only:
+       new ModConfig().Load(api)
+         ├─ api.LoadModConfig<CarryOnConfig>("CarryOnConfig.json")
+         │    └─ reads from <VintagestoryData>/ModConfig/CarryOnConfig.json
+         ├─ if null ⇒ new CarryOnConfig(CurrentConfigVersion)  // defaults
+         ├─ UpgradeVersion()  // migrates v1→2→3→4
+         ├─ api.StoreModConfig(config, "CarryOnConfig.json")
+         └─ world config tree:
+              api.World.Config
+                .GetOrAddTreeAttribute("carryon")
+                .MergeTree(config.ToTreeAttribute())
+```
+
+`ModConfig.Load()` serializes the config into the world's `ITreeAttribute` storage.
+This is how the config survives world reloads and syncs to clients.
+
+### 2b. Config Deserialization (Both Sides)
+
+After `ModConfig.Load()` has written the world config tree, `CarrySystem.StartPre()`
+reads it back:
+
+```
+CarrySystem.StartPre()
+  ├─ Api.Side == server:
+  │    ModConfig.Load(api)          // loads file → world config tree
+  │
+  ├─ Api.Side == client:
+  │    (world config tree already synced by VS network layer)
+  │
+  ├─ config = api.World.Config["carryon"] is ITreeAttribute tree
+  │    ? CarryOnConfig.FromTreeAttribute(tree)   // deserialize from tree
+  │    : new CarryOnConfig()                     // fallback defaults
+  │
+  └─ ConfigService = new CarryOnConfigService(config)
+```
+
+The **client** never reads `CarryOnConfig.json` from disk. It receives the config
+via the server's world config sync or via the `ConfigSyncMessage` network packet.
+
+### 2c. Config Distribution
+
+In `CarrySystem.Start()`:
+
+```
+CarrySystem.Start()
+  ├─ CarryManager = new CarryManager(api, this, CarryEvents)
+  │    └─ this (CarrySystem) is passed as IConfigProvider
+  │    └─ CarryManager.Config ⇒ ConfigProvider.Config ⇒ CarrySystem.Config ⇒ ConfigService.Config
+  │
+  ├─ CarryHandler = new CarryHandler(carryManager, this.Config, ...)
+  │    └─ stores private copy of config (mutable, updated via UpdateConfig())
+  │
+  ├─ (client only) EntityCarryRenderer = new(api, carryManager, this.Config, ...)
+  │    └─ stores private copy, passes to CacheManager & Dispatcher
+  │
+  └─ WireConfigChangeHandlers()
+       └─ subscribes to ConfigService.OnConfigChanged
+```
+
+---
+
+## 3. Config Consumer Chain
+
+```
+CarrySystem (IConfigProvider)
+  │
+  ├── Config property ⇒ ConfigService.Config
+  │
+  ├── AS IConfigProvider → CarryManager constructor
+  │    └── CarryManager.Config (delegates to IConfigProvider.Config)
+  │
+  ├── AS CarryOnConfig (value copy) → CarryHandler
+  │    └── → CarryInteractionController (via InitClient)
+  │         └── → CarryInteractionValidator
+  │              └── Invalidates parsed arrays (PreventSwapFromBackOnTarget)
+  │
+  ├── AS CarryOnConfig (value copy) → EntityCarryRenderer
+  │    └── → CarryRenderCacheManager
+  │    └── → CarryRenderDispatcher
+  │
+  └── AS CarryOnConfig (value copy) → BehavioralConditioning.Init(api, config)
+       └── One-shot at AssetsFinalize (not wired to reload)
+```
+
+Every consumer stores a **private mutable field** for config, then relies on
+`UpdateConfig()` to receive new instances on change.
+
+---
+
+## 4. Config Hotloading
+
+### 4a. Triggers
+
+| Trigger | Initiator | Path |
+|---|---|---|
+| File change (disk) | `CarryOnConfigService.SetupFileWatcher()` | `OnConfigFileChanged()` → `ReloadFromFile()` → `Replace()` |
+| Network sync | Server broadcasts `ConfigSyncMessage` | Client `CarrySystem.OnClientConfigSync()` → `ConfigService.Replace()` |
+| Console command | `/carryon reload` | Calls `ConfigService.Reload()` |
+| Programmatic | Any code | Calls `ConfigService.Replace(newConfig)` |
+
+### 4b. File Watcher (Server Only)
+
+`CarryOnConfigService.SetupFileWatcher(ICoreServerAPI)` creates a
+`FileSystemWatcher` on `<VintagestoryData>/ModConfig/CarryOnConfig.json`:
+
+```
+FileSystemWatcher.Changed / .Created
+  └─ OnConfigFileChanged()
+       ├─ debounce 500ms (prevents double-fire)
+       ├─ Thread.Sleep(100)  (let file IO settle)
+       └─ api.Event.EnqueueMainThreadTask(ReloadFromFile)
+            ├─ api.LoadModConfig<CarryOnConfig>(ConfigFile)
+            ├─ reloaded.UpgradeVersion()
+            └─ Replace(reloaded)
+                 ├─ Config = newConfig
+                 └─ OnConfigChanged?.Invoke(newConfig)
+```
+
+Disabled when `DebuggingOptions.DisableConfigWatcher` is `true`.
+
+### 4c. `Replace()` — The Central Mutation Point
+
+`CarryOnConfigService.Replace(CarryOnConfig newConfig)` is the single entry
+point for all config changes. It swaps the in-memory config and fires the event:
+
+```csharp
+public void Replace(CarryOnConfig newConfig)
+{
+    Config = newConfig;
+    OnConfigChanged?.Invoke(newConfig);
+}
+```
+
+### 4d. Subscriber Chain (`WireConfigChangeHandlers()`)
+
+All in `CarrySystem.Start()`:
+
+| Order | Subscriber | Effect |
+|---|---|---|
+| 1 | `Config.InvalidateBackpackCache()` | Clears lazy-parsed `BackpackMapping` dictionary |
+| 2 | `CarryHandler?.UpdateConfig(cfg)` | Updates private config; forwards to `InteractionController` → `Validator` → `InvalidateConfigCache()` (re-parses `PreventSwapFromBackOnTarget` filters) |
+| 3 | `EntityCarryRenderer?.UpdateConfig(cfg)` | Updates private config; forwards to `CacheManager.UpdateConfig()`, `Dispatcher.UpdateConfig()` |
+| 4 | `EntityCarriedBlock.Config = Config.CarriedBlockEntity` | Carried block entity behavior settings |
+| 5 | (server) persist to world config + disk | `ServerApi.StoreModConfig(Config, ConfigFile)` |
+| 6 | (server) broadcast to clients | `ServerChannel.BroadcastPacket(new ConfigSyncMessage(json))` |
+
+### 4e. Network Sync
+
+```
+Server (OnConfigChanged):
+  ├─ json = JsonConvert.SerializeObject(Config)
+  └─ ServerChannel.BroadcastPacket(new ConfigSyncMessage(json))
+
+Client (CarrySystem.OnClientConfigSync):
+  ├─ var reloaded = JsonConvert.DeserializeObject<CarryOnConfig>(message.ConfigJson)
+  ├─ reloaded.UpgradeVersion()
+  └─ ConfigService.Replace(reloaded)
+       └─ fires OnConfigChanged (subscribers 1-4 above run client-side)
+```
+
+---
+
+## 5. Flow Diagram
+
+```
+                          ┌──────────────────────────────┐
+                          │       CarryOnConfig.json      │
+                          │  <VintagestoryData>/ModConfig │
+                          └──────────────┬───────────────┘
+                                         │
+                          ┌──────────────▼───────────────┐
+                          │  ModConfig.Load(api)         │
+                          │  (server StartPre)           │
+                          │  • LoadModConfig             │
+                          │  • UpgradeVersion            │
+                          │  • StoreModConfig            │
+                          │  • worldConfig.MergeTree()   │
+                          └──────────────┬───────────────┘
+                                         │ (via world config ITreeAttribute)
+                          ┌──────────────▼───────────────┐
+                          │  CarryOnConfig.FromTreeAttr()│
+                          │  (both sides, StartPre)      │
+                          └──────────────┬───────────────┘
+                                         │
+                          ┌──────────────▼───────────────┐
+                          │  CarryOnConfigService(config) │
+                          │  • Config property            │
+                          │  • OnConfigChanged event      │
+                          │  • Replace() / Reload()       │
+                          │  • SetupFileWatcher()         │
+                          └──────┬───────────────────────┘
+                                 │
+                    ┌────────────┼────────────────────────────┐
+                    │            │                            │
+         ┌──────────▼────┐ ┌────▼──────────┐     ┌───────────▼──────────┐
+         │  CarrySystem   │ │ CarryHandler  │     │ EntityCarryRenderer  │
+         │  (IConfigPro-  │ │ (private copy)│     │ (private copy)       │
+         │   vider)       │ │              │     │                      │
+         │  Config ⇒      │ │ UpdateConfig │     │ UpdateConfig         │
+         │  ConfigService │ │   ↓           │     │   ↓                  │
+         │                │ │ Interaction   │     ├─ CacheManager        │
+         │  Passed as     │ │ Controller    │     └─ Dispatcher         │
+         │  IConfigProv.  │ │   ↓           │                          │
+         │  → CarryManager│ │ Validator     │                          │
+         └────────────────┘ └──────────────┘     └──────────────────────┘
+
+                     HOT RELOAD FLOW (server):
+
+  Disk change ──► FileWatcher ──► ReloadFromFile()
+                                    │
+                                    ▼
+  /carryon reload ─────────────► Reload() ──► Replace(newConfig)
+                                    │
+                                    ▼
+                            OnConfigChanged
+                                    │
+              ┌─────────────────────┼──────────────────────┐
+              ▼                     ▼                      ▼
+      InvalidateBackpack     Update Consumers        Broadcast to
+              │              (Handler, Renderer,     Clients via
+              │               EntityCarriedBlock)    ConfigSyncMessage
+              │                                         │
+              ▼                                         ▼
+      BackpackMapping                              Client Dispatches
+      recalculated on                              OnClientConfigSync
+      next access                                         │
+                                                          ▼
+                                                   ConfigService.Replace()
+                                                          │
+                                                          ▼
+                                                   OnConfigChanged
+                                                   (client-side subscribers)
+```
+
+---
+
+## 6. Key Design Points
+
+- **ConfigService is the single source of truth.** `CarrySystem.Config` delegates
+  to it. `CarryManager.Config` delegates through `CarrySystem` via `IConfigProvider`.
+- **Private mutable copies.** Most consumers take a config snapshot at construction
+  and rely on `UpdateConfig()` for hot-reload. This avoids coupling to the service
+  lifecycle and makes testing simpler.
+- **Server-authoritative.** Only the server can trigger hot-reload from disk.
+  Clients receive the config as a serialized JSON message.
+- **Two serializations at startup.** `ModConfig.Load()` writes POCO → `ITreeAttribute`
+  (world config), then `StartPre()` reads `ITreeAttribute` → POCO. This ensures
+  the config is always consistent with world storage.
+- **`BehavioralConditioning` is NOT wired to hot-reload.** It runs once at
+  `AssetsFinalize`. Carryables, interactables, and filter changes require restart.

--- a/docs/technical-overview/config-initialization-and-flow.md
+++ b/docs/technical-overview/config-initialization-and-flow.md
@@ -255,10 +255,16 @@ sequenceDiagram
     Server->>Server: JsonConvert.SerializeObject(Config)
     Server->>Clients: BroadcastPacket(ConfigSyncMessage(json))
     Clients->>Clients: OnClientConfigSync(message)
-    Clients->>Clients: Deserialize + UpgradeVersion
+    Clients->>Clients: Deserialize + UpgradeVersion (*)
     Clients->>Clients: ConfigService.Replace(reloaded)
     Clients->>Clients: OnConfigChanged fired (client subscribers)
 ```
+
+> **(\*) `UpgradeVersion()` is a no-op on this path.** The server always
+> serializes its already-upgraded config (current version 4). The client
+> calls `UpgradeVersion` only because it uses the same `CarryOnConfig`
+> deserialization code path as the server — a defensive guard in case the
+> source is an older server or corrupt data.
 
 ---
 

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -142,7 +142,7 @@ namespace CarryOn
             if (CarryOnLib != null)
             {
                 CarryOnLib.CarryManager = new CarryManager(api, this, CarryEvents);
-                CarryHandler = new CarryHandler(CarryOnLib.CarryManager, this.Config, () => this.ClientModConfig?.Config?.CarryOnEnabled ?? true);
+                CarryHandler = new CarryHandler(CarryOnLib.CarryManager, () => this.ClientModConfig?.Config?.CarryOnEnabled ?? true);
                 HotKeyHandler = new HotKeyHandler(CarryOnLib.CarryManager);
             }
             else
@@ -157,8 +157,7 @@ namespace CarryOn
         private void WireConfigChangeHandlers()
         {
             ConfigService.OnConfigChanged += _ => Config.InvalidateBackpackCache();
-            ConfigService.OnConfigChanged += cfg => this.CarryHandler?.UpdateConfig(cfg);
-            ConfigService.OnConfigChanged += cfg => this.EntityCarryRenderer?.UpdateConfig(cfg);
+            ConfigService.OnConfigChanged += _ => this.CarryHandler?.RefreshConfigCache();
             ConfigService.OnConfigChanged += _ => EntityCarriedBlock.Config = Config.CarriedBlockEntity;
             ConfigService.OnConfigChanged += _ =>
             {
@@ -232,7 +231,7 @@ namespace CarryOn
 
             HudCarried.UpdateParsedColors();
 
-            EntityCarryRenderer = new EntityCarryRenderer(api, this.CarryManager, this.Config, this.ClientModConfig!);
+            EntityCarryRenderer = new EntityCarryRenderer(api, this.CarryManager, this.ClientModConfig!);
 
             CarryHandler!.InitClient(api, this.ClientChannel!,
                 () => { if (this.HudOverlayRenderer != null) this.HudOverlayRenderer.CircleVisible = false; },

--- a/src/CarrySystem.cs
+++ b/src/CarrySystem.cs
@@ -85,25 +85,29 @@ namespace CarryOn
             else
             {
                 ServerApi = api as ICoreServerAPI;
-
-                // Load the configuration into the world config
-                var modConfig = new ModConfig();
-                modConfig.Load(api);
             }
 
             base.StartPre(api);
 
-            var carryOnWorldConfig = api.World.Config?.GetTreeAttribute(ModId);
-
             CarryOnConfig config;
-            if (carryOnWorldConfig == null)
+
+            if (api is ICoreServerAPI sapi)
             {
-                api.World.Logger.Warning("CarryOn: No world config found for CarryOn; using defaults");
-                config = new CarryOnConfig();
+                // Load from disk and sync to world config for client access
+                config = new ModConfig().Load(sapi) ?? new CarryOnConfig();
             }
             else
             {
-                config = CarryOnConfig.FromTreeAttribute(carryOnWorldConfig);
+                var carryOnWorldConfig = api.World.Config?.GetTreeAttribute(ModId);
+                if (carryOnWorldConfig == null)
+                {
+                    api.World.Logger.Warning("CarryOn: No world config found for CarryOn; using defaults");
+                    config = new CarryOnConfig();
+                }
+                else
+                {
+                    config = CarryOnConfig.FromTreeAttribute(carryOnWorldConfig);
+                }
             }
 
             ConfigService = new CarryOnConfigService(config);

--- a/src/Client/Logic/CarryRenderer/CarryRenderCacheManager.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderCacheManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CarryOn.API.Common.Interfaces;
 using CarryOn.API.Common.Models;
 using CarryOn.Common.Models;
+using CarryOn.Common.Interfaces;
 using CarryOn.Client.Models;
 using CarryOn.Utility;
 using Vintagestory.API.Client;
@@ -16,25 +17,22 @@ namespace CarryOn.Client.Logic.CarryRenderer
     {
         private readonly ICoreClientAPI api;
         private readonly ICarryManager carryManager;
-        private CarryOnConfig config;
+        private readonly IConfigProvider configProvider;
         private readonly CarryTransformPlanBuilder planBuilder;
         private readonly CarryRenderInfoBuilder infoBuilder;
         private readonly CarryRenderCache cache;
 
-        public CarryRenderCacheManager(ICoreClientAPI api, ICarryManager carryManager, CarryOnConfig config, CarryTransformPlanBuilder planBuilder, CarryRenderInfoBuilder infoBuilder, CarryRenderCache cache)
+        public CarryRenderCacheManager(ICoreClientAPI api, ICarryManager carryManager, CarryTransformPlanBuilder planBuilder, CarryRenderInfoBuilder infoBuilder, CarryRenderCache cache)
         {
             this.api = api ?? throw new ArgumentNullException(nameof(api));
             this.carryManager = carryManager ?? throw new ArgumentNullException(nameof(carryManager));
-            this.config = config ?? throw new ArgumentNullException(nameof(config));
+            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.planBuilder = planBuilder ?? throw new ArgumentNullException(nameof(planBuilder));
             this.infoBuilder = infoBuilder ?? throw new ArgumentNullException(nameof(infoBuilder));
             this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
         }
 
-        public void UpdateConfig(CarryOnConfig newConfig)
-        {
-            this.config = newConfig;
-        }
+        public CarryOnConfig Config => configProvider.Config;
 
         private readonly Dictionary<(long EntityId, CarrySlot Slot), SignatureSidecarState> signatureSidecars = new();
 
@@ -205,7 +203,7 @@ namespace CarryOn.Client.Logic.CarryRenderer
 
         public void TryLogCounters(ICoreClientAPI api)
         {
-            var loggingEnabled = config?.DebuggingOptions?.LoggingEnabled ?? false;
+            var loggingEnabled = Config?.DebuggingOptions?.LoggingEnabled ?? false;
             if (!loggingEnabled) return;
 
             var now = DateTime.UtcNow;

--- a/src/Client/Logic/CarryRenderer/CarryRenderCacheManager.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderCacheManager.cs
@@ -26,7 +26,7 @@ namespace CarryOn.Client.Logic.CarryRenderer
         {
             this.api = api ?? throw new ArgumentNullException(nameof(api));
             this.carryManager = carryManager ?? throw new ArgumentNullException(nameof(carryManager));
-            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
+            this.configProvider = carryManager as IConfigProvider ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.planBuilder = planBuilder ?? throw new ArgumentNullException(nameof(planBuilder));
             this.infoBuilder = infoBuilder ?? throw new ArgumentNullException(nameof(infoBuilder));
             this.cache = cache ?? throw new ArgumentNullException(nameof(cache));

--- a/src/Client/Logic/CarryRenderer/CarryRenderDispatcher.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderDispatcher.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CarryOn.API.Common.Interfaces;
 using CarryOn.API.Common.Models;
 using CarryOn.Common.Models;
+using CarryOn.Common.Interfaces;
 using CarryOn.Client.Models;
 using CarryOn.Utility;
 using Vintagestory.API.Client;
@@ -18,27 +19,22 @@ namespace CarryOn.Client.Logic.CarryRenderer
     {
         private readonly ICoreClientAPI api;
         private readonly ICarryManager carryManager;
-        private CarryOnConfig config;
+        private readonly IConfigProvider configProvider;
         private readonly CarryRenderCacheManager cacheManager;
         private readonly CarryFirstPersonRenderer firstPersonRenderer;
         private readonly CarriedLabelRenderer labelRenderer;
         private readonly bool renderAttachedBlocks;
 
-        public CarryRenderDispatcher(ICoreClientAPI api, ICarryManager carryManager, CarryOnConfig config, CarryRenderCacheManager cacheManager, CarryFirstPersonRenderer firstPersonRenderer, CarriedLabelRenderer labelRenderer, bool renderAttachedBlocks = true)
+        public CarryRenderDispatcher(ICoreClientAPI api, ICarryManager carryManager, CarryRenderCacheManager cacheManager, CarryFirstPersonRenderer firstPersonRenderer, CarriedLabelRenderer labelRenderer, bool renderAttachedBlocks = true)
         {
             this.api = api ?? throw new ArgumentNullException(nameof(api));
             this.carryManager = carryManager ?? throw new ArgumentNullException(nameof(carryManager));
-            this.config = config ?? throw new ArgumentNullException(nameof(config));
+            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.cacheManager = cacheManager ?? throw new ArgumentNullException(nameof(cacheManager));
             this.firstPersonRenderer = firstPersonRenderer ?? throw new ArgumentNullException(nameof(firstPersonRenderer));
             this.labelRenderer = labelRenderer ?? throw new ArgumentNullException(nameof(labelRenderer));
             this.renderAttachedBlocks = renderAttachedBlocks;
             this.RenderAttachedBlocks = renderAttachedBlocks;
-        }
-
-        public void UpdateConfig(CarryOnConfig newConfig)
-        {
-            this.config = newConfig;
         }
 
         private const float FirstPersonVerticalOffset = -0.05F;
@@ -156,7 +152,7 @@ namespace CarryOn.Client.Logic.CarryRenderer
             }
             var viewMat = cachedViewMat;
 
-            string transformGroupName = entity.ResolveCarryTransformGroupBase(config, carried.Slot);
+            string transformGroupName = entity.ResolveCarryTransformGroupBase(configProvider.Config, carried.Slot);
 
             var renderSettings = RenderSettings?[carried.Slot]?[transformGroupName];
             if (renderSettings == null) return;

--- a/src/Client/Logic/CarryRenderer/CarryRenderDispatcher.cs
+++ b/src/Client/Logic/CarryRenderer/CarryRenderDispatcher.cs
@@ -29,7 +29,7 @@ namespace CarryOn.Client.Logic.CarryRenderer
         {
             this.api = api ?? throw new ArgumentNullException(nameof(api));
             this.carryManager = carryManager ?? throw new ArgumentNullException(nameof(carryManager));
-            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
+            this.configProvider = carryManager as IConfigProvider ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.cacheManager = cacheManager ?? throw new ArgumentNullException(nameof(cacheManager));
             this.firstPersonRenderer = firstPersonRenderer ?? throw new ArgumentNullException(nameof(firstPersonRenderer));
             this.labelRenderer = labelRenderer ?? throw new ArgumentNullException(nameof(labelRenderer));

--- a/src/Client/Logic/CarryRenderer/EntityCarryRenderer.cs
+++ b/src/Client/Logic/CarryRenderer/EntityCarryRenderer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using CarryOn.API.Common.Interfaces;
-using CarryOn.Common.Models;
 using CarryOn.Client.Models;
 using Vintagestory.API.Client;
 
@@ -10,7 +9,6 @@ namespace CarryOn.Client.Logic.CarryRenderer
     public class EntityCarryRenderer : IRenderer
     {
         private ICarryManager carryManager { get; }
-        private CarryOnConfig config;
         private ICoreClientAPI api { get; }
         private long renderTick;
         private readonly CarryAnimationSync animationSync;
@@ -20,12 +18,11 @@ namespace CarryOn.Client.Logic.CarryRenderer
         private readonly ClientModConfig clientModConfig;
         private readonly CarryRenderInfoBuilder infoBuilder;
 
-        public EntityCarryRenderer(ICoreClientAPI api, ICarryManager carryManager, CarryOnConfig config, ClientModConfig clientModConfig)
+        public EntityCarryRenderer(ICoreClientAPI api, ICarryManager carryManager, ClientModConfig clientModConfig)
         {
             ArgumentNullException.ThrowIfNull(api);
 
             this.carryManager = carryManager;
-            this.config = config;
             this.api = api;
             this.clientModConfig = clientModConfig;
 
@@ -38,8 +35,8 @@ namespace CarryOn.Client.Logic.CarryRenderer
             infoBuilder = new CarryRenderInfoBuilder(api, renderAttached);
             var labelRenderer = new CarriedLabelRenderer(api);
 
-            cacheManager = new CarryRenderCacheManager(api, carryManager, config, planBuilder, infoBuilder, cache);
-            dispatcher = new CarryRenderDispatcher(api, carryManager, config, cacheManager, firstPersonRenderer, labelRenderer, renderAttached);
+            cacheManager = new CarryRenderCacheManager(api, carryManager, planBuilder, infoBuilder, cache);
+            dispatcher = new CarryRenderDispatcher(api, carryManager, cacheManager, firstPersonRenderer, labelRenderer, renderAttached);
 
             this.api.Event.RegisterRenderer(this, EnumRenderStage.Opaque);
             this.api.Event.RegisterRenderer(this, EnumRenderStage.AfterOIT);
@@ -59,13 +56,6 @@ namespace CarryOn.Client.Logic.CarryRenderer
         }
 
         public void InvalidateRenderCaches() => cacheManager.InvalidateAll();
-
-        public void UpdateConfig(CarryOnConfig newConfig)
-        {
-            this.config = newConfig;
-            cacheManager.UpdateConfig(newConfig);
-            dispatcher.UpdateConfig(newConfig);
-        }
 
         public void SetRenderAttachedBlocks(bool enabled)
         {

--- a/src/Client/Logic/Interaction/CarryInteractionController.cs
+++ b/src/Client/Logic/Interaction/CarryInteractionController.cs
@@ -12,7 +12,6 @@ namespace CarryOn.Client.Logic.Interaction
     {
         private readonly CarryInteractionValidator validator;
         private readonly CarryInteractionStateMachine stateMachine;
-        private CarryOnConfig config;
 
         public CarryInteraction Interaction => stateMachine.Interaction;
         public Vintagestory.Client.NoObf.HudElementInteractionHelp? HudHelp
@@ -25,18 +24,16 @@ namespace CarryOn.Client.Logic.Interaction
         public bool BackSlotEnabled => validator.BackSlotEnabled;
         public float InteractSpeedMultiplier => validator.InteractSpeedMultiplier;
 
-        public CarryInteractionController(ICoreClientAPI api, ICarryManager carryManager, IClientNetworkChannel clientChannel, CarryOnConfig config, Action hideOverlay, Action<float> setOverlayProgress, ClientModConfig? clientModConfig = null)
+        public CarryInteractionController(ICoreClientAPI api, ICarryManager carryManager, IClientNetworkChannel clientChannel, Action hideOverlay, Action<float> setOverlayProgress, ClientModConfig? clientModConfig = null)
         {
             ArgumentNullException.ThrowIfNull(api);
             ArgumentNullException.ThrowIfNull(carryManager);
             ArgumentNullException.ThrowIfNull(clientChannel);
-            ArgumentNullException.ThrowIfNull(config);
             ArgumentNullException.ThrowIfNull(hideOverlay);
             ArgumentNullException.ThrowIfNull(setOverlayProgress);
 
             var transferLogic = new TransferLogic(api, carryManager);
-            this.config = config;
-            validator = new CarryInteractionValidator(api, carryManager, config, transferLogic, this);
+            validator = new CarryInteractionValidator(api, carryManager, transferLogic, this);
             stateMachine = new CarryInteractionStateMachine(api, carryManager, clientChannel, hideOverlay, setOverlayProgress, validator, transferLogic, clientModConfig);
         }
 
@@ -45,15 +42,9 @@ namespace CarryOn.Client.Logic.Interaction
             validator.TryBeginInteraction(isInteracting, ref handled);
         }
 
-        public void InvalidateConfigCache()
+        public void RefreshConfigCache()
         {
-            validator.InvalidateConfigCache();
-        }
-
-        public void UpdateConfig(CarryOnConfig newConfig)
-        {
-            this.config = newConfig;
-            validator.UpdateConfig(newConfig);
+            validator.RefreshConfigCache();
         }
 
         public void TryContinueInteraction(float deltaTime)

--- a/src/Client/Logic/Interaction/CarryInteractionValidator.cs
+++ b/src/Client/Logic/Interaction/CarryInteractionValidator.cs
@@ -39,7 +39,7 @@ namespace CarryOn.Client.Logic.Interaction
         {
             this.api = api ?? throw new ArgumentNullException(nameof(api));
             this.carryManager = carryManager ?? throw new ArgumentNullException(nameof(carryManager));
-            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
+            this.configProvider = carryManager as IConfigProvider ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.transferLogic = transferLogic ?? throw new ArgumentNullException(nameof(transferLogic));
             this.controller = controller ?? throw new ArgumentNullException(nameof(controller));
 

--- a/src/Client/Logic/Interaction/CarryInteractionValidator.cs
+++ b/src/Client/Logic/Interaction/CarryInteractionValidator.cs
@@ -6,6 +6,7 @@ using CarryOn.Common.Models;
 using CarryOn.Common.Behaviors;
 using CarryOn.Common.Logic;
 using CarryOn.Common.Entities;
+using CarryOn.Common.Interfaces;
 using CarryOn.Utility;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -18,68 +19,36 @@ namespace CarryOn.Client.Logic.Interaction
     {
         private readonly ICoreClientAPI api;
         private readonly ICarryManager carryManager;
-        private CarryOnConfig config;
+        private readonly IConfigProvider configProvider;
         private readonly TransferLogic transferLogic;
         private readonly ICarryInteractionController controller;
 
-        private Type[] preventSwapFromBackOnBehaviors;
-        private string[] preventSwapFromBackOnClasses;
-        private string[] preventSwapFromBackOnCodes;
+        private Type[] preventSwapFromBackOnBehaviors = [];
+        private string[] preventSwapFromBackOnClasses = [];
+        private string[] preventSwapFromBackOnCodes = [];
 
-        public bool RemoveInteractDelayWhileCarrying => this.config?.CarryOptions?.RemoveInteractDelayWhileCarrying ?? false;
-        public bool BackSlotEnabled => this.config?.CarryOptions?.BackSlotEnabled ?? false;
-        public float InteractSpeedMultiplier => this.config?.CarryOptions?.InteractSpeedMultiplier ?? 1.0f;
+        public bool RemoveInteractDelayWhileCarrying => configProvider.Config.CarryOptions?.RemoveInteractDelayWhileCarrying ?? false;
+        public bool BackSlotEnabled => configProvider.Config.CarryOptions?.BackSlotEnabled ?? false;
+        public float InteractSpeedMultiplier => configProvider.Config.CarryOptions?.InteractSpeedMultiplier ?? 1.0f;
 
         public CarryInteractionValidator(
             ICoreClientAPI api,
             ICarryManager carryManager,
-            CarryOnConfig config,
             TransferLogic transferLogic,
             ICarryInteractionController controller)
         {
             this.api = api ?? throw new ArgumentNullException(nameof(api));
             this.carryManager = carryManager ?? throw new ArgumentNullException(nameof(carryManager));
-            this.config = config ?? throw new ArgumentNullException(nameof(config));
+            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.transferLogic = transferLogic ?? throw new ArgumentNullException(nameof(transferLogic));
             this.controller = controller ?? throw new ArgumentNullException(nameof(controller));
 
-            const string behaviorPrefix = "behavior::";
-            const string classPrefix = "class::";
-            const string codePrefix = "code::";
-
-            if (config != null)
-            {
-                var entries = config?.CarryOptions?.PreventSwapFromBackOnTarget ?? Array.Empty<string>();
-
-                preventSwapFromBackOnBehaviors = entries
-                    .Where(x => x.StartsWith(behaviorPrefix))
-                    .Select(x => api.ClassRegistry.GetBlockBehaviorClass(x.Substring(behaviorPrefix.Length)))
-                    .Where(x => x != null)
-                    .ToArray();
-
-                preventSwapFromBackOnClasses = entries
-                    .Where(x => x.StartsWith(classPrefix))
-                    .Select(x => x.Substring(classPrefix.Length))
-                    .Where(x => !string.IsNullOrWhiteSpace(x))
-                    .ToArray();
-
-                preventSwapFromBackOnCodes = entries
-                    .Where(x => x.StartsWith(codePrefix))
-                    .Select(x => x.Substring(codePrefix.Length))
-                    .Where(x => !string.IsNullOrWhiteSpace(x))
-                    .ToArray();
-            }
-            else
-            {
-                preventSwapFromBackOnBehaviors = [];
-                preventSwapFromBackOnClasses = [];
-                preventSwapFromBackOnCodes = [];
-            }
+            RefreshConfigCache();
         }
 
-        public void InvalidateConfigCache()
+        public void RefreshConfigCache()
         {
-            var entries = config?.CarryOptions?.PreventSwapFromBackOnTarget ?? Array.Empty<string>();
+            var entries = configProvider.Config?.CarryOptions?.PreventSwapFromBackOnTarget ?? Array.Empty<string>();
             const string behaviorPrefix = "behavior::";
             const string classPrefix = "class::";
             const string codePrefix = "code::";
@@ -101,12 +70,6 @@ namespace CarryOn.Client.Logic.Interaction
                 .Select(x => x.Substring(codePrefix.Length))
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .ToArray();
-        }
-
-        public void UpdateConfig(CarryOnConfig newConfig)
-        {
-            this.config = newConfig;
-            InvalidateConfigCache();
         }
 
         public void TryBeginInteraction(bool isInteracting, ref EnumHandling handled)
@@ -225,7 +188,7 @@ namespace CarryOn.Client.Logic.Interaction
             var entitySelection = this.api.World.Player.CurrentEntitySelection;
             if (entitySelection?.Entity is not EntityCarriedBlock carriedBlockEntity) return false;
 
-            var cfg = this.config.CarriedBlockEntity;
+            var cfg = configProvider.Config.CarriedBlockEntity;
             if (cfg != null)
             {
                 var canPickup = CarriedBlockAccessPolicy.CanPickup(
@@ -257,7 +220,7 @@ namespace CarryOn.Client.Logic.Interaction
             var carriedHands = carryManager.GetCarried(player.Entity, CarrySlot.Hands);
             var carriedBack = carryManager.GetCarried(player.Entity, CarrySlot.Back);
 
-            var backSlotEnabled = this.config?.CarryOptions?.BackSlotEnabled ?? false;
+            var backSlotEnabled = configProvider.Config.CarryOptions?.BackSlotEnabled ?? false;
             if (carriedHands != null && !backSlotEnabled) return false;
 
             if (!player.Entity.CanInteract(requireEmptyHanded: true))

--- a/src/Common/Handlers/CarryHandler.cs
+++ b/src/Common/Handlers/CarryHandler.cs
@@ -16,6 +16,7 @@ using CarryOn.Common.Logic;
 using CarryOn.API.Common.Interfaces;
 using CarryOn.API.Common.Models;
 using CarryOn.Client.Logic.Interaction;
+using CarryOn.Common.Interfaces;
 using CarryOn.Client.Models;
 using CarryOn.Common.Entities;
 using static CarryOn.Common.Models.CarryCode;
@@ -47,16 +48,16 @@ namespace CarryOn.Common.Handlers
 
         private long gameTickListenerId;
 
-        private CarryOnConfig config;
         private readonly Func<bool> getIsCarryOnEnabled;
 
         private readonly ICarryManager carryManager;
+        private readonly IConfigProvider configProvider;
 
         public bool IsCarryOnEnabled => this.getIsCarryOnEnabled();
 
         private bool lastCanInteractState = true;
 
-        public bool BackSlotEnabled => this.config.CarryOptions?.BackSlotEnabled ?? false;
+        public bool BackSlotEnabled => configProvider.Config.CarryOptions?.BackSlotEnabled ?? false;
 
         private ICoreAPI? api;
 
@@ -77,7 +78,7 @@ namespace CarryOn.Common.Handlers
 
         private bool CanSprintWhileCarrying(EntityPlayer player)
         {
-            var cfg = this.config?.CarryWalkSpeed;
+            var cfg = this.configProvider.Config.CarryWalkSpeed;
             if (cfg == null) return true;
 
             var handsCarried = this.carryManager.GetCarried(player, CarrySlot.Hands);
@@ -103,30 +104,22 @@ namespace CarryOn.Common.Handlers
             this.interactionLogic.HudHelp = hudHelp;
         }
 
-        public void InvalidateConfigCache()
+        public void RefreshConfigCache()
         {
-            interactionLogic?.InvalidateConfigCache();
-        }
-
-        public void UpdateConfig(CarryOnConfig newConfig)
-        {
-            this.config = newConfig;
-            interactionLogic?.UpdateConfig(newConfig);
+            interactionLogic?.RefreshConfigCache();
         }
 
         /// <summary>
         /// Initializes a new instance of the CarryHandler class.
         /// </summary>
-        /// <param name="config"> The CarryOn configuration. </param>
         /// <param name="isCarryOnEnabled"> Function returning the current CarryOn enabled state (client-side). </param>
-        public CarryHandler(ICarryManager carryManager, CarryOnConfig config, Func<bool> isCarryOnEnabled)
+        public CarryHandler(ICarryManager carryManager, Func<bool> isCarryOnEnabled)
         {
             ArgumentNullException.ThrowIfNull(carryManager);
-            ArgumentNullException.ThrowIfNull(config);
             ArgumentNullException.ThrowIfNull(isCarryOnEnabled);
             
             this.carryManager = carryManager;
-            this.config = config;
+            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.getIsCarryOnEnabled = isCarryOnEnabled;
         }
 
@@ -157,7 +150,7 @@ namespace CarryOn.Common.Handlers
             ArgumentNullException.ThrowIfNull(hideOverlay);
             ArgumentNullException.ThrowIfNull(setOverlayProgress);
 
-            this.interactionLogic = new CarryInteractionController(ClientApi, this.carryManager, clientChannel, this.config, hideOverlay, setOverlayProgress, clientModConfig);
+            this.interactionLogic = new CarryInteractionController(ClientApi, this.carryManager, clientChannel, hideOverlay, setOverlayProgress, clientModConfig);
 
             RegisterCarryMessageTypes(clientChannel)
                 .SetMessageHandler<LockSlotsMessage>(OnLockSlotsMessage);
@@ -608,7 +601,7 @@ namespace CarryOn.Common.Handlers
 
         private bool CanPickupFromEntity(IServerPlayer player, EntityCarriedBlock entity)
         {
-            var cfg = this.config.CarriedBlockEntity;
+            var cfg = this.configProvider.Config.CarriedBlockEntity;
             if (cfg == null) return true;
 
             if (!CarriedBlockAccessPolicy.CanPickup(

--- a/src/Common/Handlers/CarryHandler.cs
+++ b/src/Common/Handlers/CarryHandler.cs
@@ -119,7 +119,7 @@ namespace CarryOn.Common.Handlers
             ArgumentNullException.ThrowIfNull(isCarryOnEnabled);
             
             this.carryManager = carryManager;
-            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
+            this.configProvider = carryManager as IConfigProvider ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             this.getIsCarryOnEnabled = isCarryOnEnabled;
         }
 

--- a/src/Common/Logic/CarryableInteractionHelpBuilder.cs
+++ b/src/Common/Logic/CarryableInteractionHelpBuilder.cs
@@ -19,7 +19,7 @@ namespace CarryOn.Common.Logic
         public static void Init(ICarryManager manager)
         {
             carryManager = manager ?? throw new ArgumentNullException(nameof(manager));
-            configProvider = (IConfigProvider)manager ?? throw new ArgumentException("manager must implement IConfigProvider", nameof(manager));
+            configProvider = manager as IConfigProvider ?? throw new ArgumentException("manager must implement IConfigProvider", nameof(manager));
         }
 
         private static ItemStack[]? handsfreeStacks;

--- a/src/Common/Logic/CarryableInteractionHelpBuilder.cs
+++ b/src/Common/Logic/CarryableInteractionHelpBuilder.cs
@@ -14,10 +14,12 @@ namespace CarryOn.Common.Logic
     public static class CarryableInteractionHelpBuilder
     {
         private static ICarryManager? carryManager;
+        private static IConfigProvider configProvider = null!;
 
         public static void Init(ICarryManager manager)
         {
             carryManager = manager ?? throw new ArgumentNullException(nameof(manager));
+            configProvider = (IConfigProvider)manager ?? throw new ArgumentException("manager must implement IConfigProvider", nameof(manager));
         }
 
         private static ItemStack[]? handsfreeStacks;
@@ -46,7 +48,7 @@ namespace CarryOn.Common.Logic
             bool isTargetCarryable = selection?.Block != null && itemStack != null;
 
             // Suppress pickup hints when the client-side permission check denies access
-            if ((carryManager as IConfigProvider)?.Config?.CarryOptions?.ClientSidePermissionCheck == true &&
+            if (configProvider.Config.CarryOptions?.ClientSidePermissionCheck == true &&
                 forPlayer?.Entity != null && selection?.Position != null &&
                 !carryManager!.HasPermissionAt(forPlayer.Entity, selection.Position))
             {

--- a/src/Common/Models/CarryOnConfig.cs
+++ b/src/Common/Models/CarryOnConfig.cs
@@ -322,7 +322,7 @@ namespace CarryOn.Common.Models
         [TreeValue("LoggingEnabled")] public bool LoggingEnabled { get; set; } = false;
 
         [DisplayName("Disable Harmony Patch")]
-        [Description("Disable Harmony runtime patching â€” changes require a server restart")]
+        [Description("Disable Harmony runtime patching - changes require a server restart")]
         [DefaultValue(false)]
         [TreeValue("DisableHarmonyPatch")] public bool DisableHarmonyPatch { get; set; } = false;
 
@@ -346,17 +346,17 @@ namespace CarryOn.Common.Models
 
         [Category("Carryables (requires restart)")]
         [DisplayName("Carryables")]
-        [Description("Which blocks can be carried â€” changes require a server restart to take effect")]
+        [Description("Which blocks can be carried - changes require a server restart to take effect")]
         public CarryablesConfig Carryables { get; set; } = new CarryablesConfig();
 
         [Category("Carryables on Back (requires restart)")]
         [DisplayName("Carryables on Back")]
-        [Description("Which blocks can be placed on the back slot â€” changes require a server restart")]
+        [Description("Which blocks can be placed on the back slot - changes require a server restart")]
         public CarryablesOnBackConfig CarryablesOnBack { get; set; } = new CarryablesOnBackConfig();
 
         [Category("Interactables (requires restart)")]
         [DisplayName("Interactables")]
-        [Description("Which block interactions are allowed while carrying â€” changes require a server restart")]
+        [Description("Which block interactions are allowed while carrying - changes require a server restart")]
         public InteractablesConfig Interactables { get; set; } = new InteractablesConfig();
 
         [Category("Hunger Rate")]
@@ -376,7 +376,7 @@ namespace CarryOn.Common.Models
 
         [Category("Carryable Filters (requires restart)")]
         [DisplayName("Carryable Filters")]
-        [Description("Advanced carryable filtering rules â€” changes require a server restart")]
+        [Description("Advanced carryable filtering rules - changes require a server restart")]
         public CarryablesFiltersConfig CarryablesFilters { get; set; } = new CarryablesFiltersConfig();
 
         [JsonIgnore]
@@ -417,7 +417,7 @@ namespace CarryOn.Common.Models
 
         [Category("Debugging (requires restart)")]
         [DisplayName("Debugging")]
-        [Description("Debug and developer options â€” some changes require a server restart")]
+        [Description("Debug and developer options - some changes require a server restart")]
         public DebuggingOptionsConfig DebuggingOptions { get; set; } = new DebuggingOptionsConfig();
 
         [JsonExtensionData(ReadData = true, WriteData = false)]

--- a/src/Common/Services/CarryDropService.cs
+++ b/src/Common/Services/CarryDropService.cs
@@ -135,7 +135,7 @@ namespace CarryOn.Common.Services
                 return;
             }
 
-            // Cluster placement failed -drop parent plus all children as items
+            // Cluster placement failed - drop parent plus all children as items
             var world = api.World;
             var dropVec3d = new Vec3d(centerBlock.X + 0.5, centerBlock.Y + 0.5, centerBlock.Z + 0.5);
 

--- a/src/Common/Services/CarryDropService.cs
+++ b/src/Common/Services/CarryDropService.cs
@@ -135,7 +135,7 @@ namespace CarryOn.Common.Services
                 return;
             }
 
-            // Cluster placement failed â€” drop parent plus all children as items
+            // Cluster placement failed -drop parent plus all children as items
             var world = api.World;
             var dropVec3d = new Vec3d(centerBlock.X + 0.5, centerBlock.Y + 0.5, centerBlock.Z + 0.5);
 

--- a/src/Common/Services/CarryManager.cs
+++ b/src/Common/Services/CarryManager.cs
@@ -163,7 +163,7 @@ namespace CarryOn.Common.Services
 
         /// <summary>
         /// Sends a lock-slots network message to the specified player entity.
-        /// Internal â€” prefer <see cref="LockHotbarSlots"/> for public API usage.
+        /// Internal - prefer <see cref="LockHotbarSlots"/> for public API usage.
         /// </summary>
         internal void SendLockSlotsMessage(EntityPlayer player)
         {

--- a/src/Common/Services/CarryManager.cs
+++ b/src/Common/Services/CarryManager.cs
@@ -18,7 +18,7 @@ namespace CarryOn.Common.Services
     /// Default implementation of <see cref="ICarryManager"/>. Delegates all operations
     /// to the underlying service portfolio via <see cref="CarryManagerServices"/>.
     /// </summary>
-    public class CarryManager : ICarryManager
+    public class CarryManager : ICarryManager, IConfigProvider
     {
 
         public ICoreAPI Api { get; private set; }
@@ -38,7 +38,7 @@ namespace CarryOn.Common.Services
             Services = new CarryManagerServices(Api, ConfigProvider, this);
         }
 
-        public CarryOnConfig? Config => ConfigProvider?.Config;
+        public CarryOnConfig Config => ConfigProvider.Config;
 
         /// <inheritdoc/>
         public void RegisterRootTransformGroupResolver(string modId, IRootTransformGroupResolver resolver)

--- a/src/Events/DroppedBlockTracker.cs
+++ b/src/Events/DroppedBlockTracker.cs
@@ -16,18 +16,15 @@ namespace CarryOn.Events
     public class DroppedBlockTracker : ICarryEvent
     {
         private ICarryManager? carryManager;
-        private CarryOnConfig? config;
-
-        private bool loggingEnabled = false;
+        private IConfigProvider configProvider = null!;
 
         public void Init(ICarryManager carryManager)
         {
             ArgumentNullException.ThrowIfNull(carryManager);
             this.carryManager = carryManager;
-            this.config = (carryManager as IConfigProvider)?.Config;
-            this.loggingEnabled = this.config?.DebuggingOptions?.LoggingEnabled ?? false;
+            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
 
-            if (this.config?.CarryOptions?.TrackDroppedBlocks != true)
+            if (configProvider.Config.CarryOptions?.TrackDroppedBlocks != true)
                 return;
 
             var events = carryManager.CarryEvents ?? throw new InvalidOperationException("CarryEvents not initialized");
@@ -47,7 +44,7 @@ namespace CarryOn.Events
         public void OnCheckPermissionAtClient(EntityPlayer playerEntity, BlockPos pos, bool isReinforced, out bool? hasPermission)
         {
             hasPermission = null;
-            if (config?.CarryOptions?.TrackDroppedBlocks != true)
+            if (configProvider.Config.CarryOptions?.TrackDroppedBlocks != true)
                 return;
             
             // Allow client side permission so checks are done server side unless is reinforced
@@ -67,22 +64,23 @@ namespace CarryOn.Events
             // A null value means the server should continue to check other delegates
             hasPermission = null;
 
-            if (config?.CarryOptions?.TrackDroppedBlocks != true)
+            if (configProvider.Config.CarryOptions?.TrackDroppedBlocks != true)
                 return;
 
             if (isReinforced) return;
 
             var world = playerEntity.Api.World;
+            var loggingEnabled = configProvider.Config.DebuggingOptions?.LoggingEnabled ?? false;
 
             // Check if block was dropped by a player
             var droppedBlock = DroppedBlockInfo.Get(pos, playerEntity.Player);
             if (droppedBlock != null)
             {
-                if (this.loggingEnabled) world.Logger.Debug($"Dropped block found at '{pos}'");
+                if (loggingEnabled) world.Logger.Debug($"Dropped block found at '{pos}'");
                 hasPermission = true;
                 return;
             }
-            if (this.loggingEnabled) world.Logger.Debug($"No dropped block found at '{pos}'");
+            if (loggingEnabled) world.Logger.Debug($"No dropped block found at '{pos}'");
         }
 
         /// <summary>
@@ -92,7 +90,7 @@ namespace CarryOn.Events
         /// <param name="e"></param>
         public void OnCarriedBlockDropped(object? sender, BlockDroppedEventArgs e)
         {
-            if (config?.CarryOptions?.TrackDroppedBlocks != true)
+            if (configProvider.Config.CarryOptions?.TrackDroppedBlocks != true)
                 return;
 
             ArgumentNullException.ThrowIfNull(e);

--- a/src/Events/DroppedBlockTracker.cs
+++ b/src/Events/DroppedBlockTracker.cs
@@ -22,7 +22,7 @@ namespace CarryOn.Events
         {
             ArgumentNullException.ThrowIfNull(carryManager);
             this.carryManager = carryManager;
-            this.configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
+            this.configProvider = carryManager as IConfigProvider ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
 
             if (configProvider.Config.CarryOptions?.TrackDroppedBlocks != true)
                 return;

--- a/src/Events/TooHotToPickup.cs
+++ b/src/Events/TooHotToPickup.cs
@@ -1,3 +1,4 @@
+using System;
 using CarryOn.API.Common.Interfaces;
 using CarryOn.Common.Interfaces;
 using CarryOn.API.Common.Models;
@@ -16,13 +17,13 @@ namespace CarryOn.Events
     /// </summary>
     public class TooHotToPickup : ICarryEvent
     {
-        private CarryOnConfig? config;
+        private IConfigProvider configProvider = null!;
         private CarryEvents? carryEvents;
 
         public void Init(ICarryManager carryManager)
         {
-            config = (carryManager as IConfigProvider)?.Config;
-            if (config?.CarryOptions?.TooHotToCarry != true) return;
+            configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
+            if (configProvider.Config.CarryOptions?.TooHotToCarry != true) return;
 
             carryEvents = carryManager.CarryEvents;
             if (carryEvents != null)
@@ -34,7 +35,7 @@ namespace CarryOn.Events
             canPickUp = null;
             failureCode = string.Empty;
 
-            if (config?.CarryOptions?.TooHotToCarry != true)
+            if (configProvider.Config.CarryOptions?.TooHotToCarry != true)
                 return;
 
             var world = entity?.World;
@@ -54,7 +55,7 @@ namespace CarryOn.Events
             // Check if block is an oven or forge and too hot
             if (blockEntity is IHeatSource heatSource)
             {
-                var carryOptions = config?.CarryOptions;
+                var carryOptions = configProvider.Config.CarryOptions;
                 if (carryOptions != null && ((heatSource is BlockEntityOven oven && oven.ovenTemperature > carryOptions.TooHotToCarryTemperature)
                     || (heatSource is BlockEntityForge forge && forge.IsBurning)))
                 {
@@ -76,13 +77,14 @@ namespace CarryOn.Events
         {
             if (blockEntity is not IBlockEntityContainer container || container.Inventory == null) return false;
 
+            var tooHotTemp = configProvider.Config.CarryOptions.TooHotToCarryTemperature;
             foreach (var slot in container.Inventory)
             {
                 var stack = slot?.Itemstack;
                 if (stack?.Collectible == null) continue;
 
                 var temp = stack.Collectible.GetTemperature(world, stack);
-                if (config != null && temp >= config.CarryOptions.TooHotToCarryTemperature) return true;
+                if (temp >= tooHotTemp) return true;
             }
 
             return false;

--- a/src/Events/TooHotToPickup.cs
+++ b/src/Events/TooHotToPickup.cs
@@ -22,7 +22,7 @@ namespace CarryOn.Events
 
         public void Init(ICarryManager carryManager)
         {
-            configProvider = (IConfigProvider)carryManager ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
+            configProvider = carryManager as IConfigProvider ?? throw new ArgumentException("carryManager must implement IConfigProvider", nameof(carryManager));
             if (configProvider.Config.CarryOptions?.TooHotToCarry != true) return;
 
             carryEvents = carryManager.CarryEvents;

--- a/src/Server/Logic/ModConfig.cs
+++ b/src/Server/Logic/ModConfig.cs
@@ -9,39 +9,38 @@ namespace CarryOn.Server.Logic
 {
     public class ModConfig
     {
-        public CarryOnConfig? Config { get; private set; }
-
-        public void Load(ICoreAPI api)
+        public CarryOnConfig? Load(ICoreAPI api)
         {
             var coreApi = api ?? throw new ArgumentNullException(nameof(api));
-            if (coreApi.Side != EnumAppSide.Server) return;
+            if (coreApi.Side != EnumAppSide.Server) return null;
 
+            CarryOnConfig config;
             try
             {
                 var loadedConfig = coreApi.LoadModConfig<CarryOnConfig>(ConfigFile);
                 if (loadedConfig != null)
                 {
                     loadedConfig.UpgradeVersion();
-                    Config = loadedConfig;
+                    config = loadedConfig;
                 }
                 else
                 {
-                    Config = new CarryOnConfig(CurrentConfigVersion);
+                    config = new CarryOnConfig(CurrentConfigVersion);
                 }
 
-                coreApi.StoreModConfig(Config, ConfigFile);
+                coreApi.StoreModConfig(config, ConfigFile);
             }
             catch (Exception ex)
             {
                 coreApi.Logger?.Error("CarryOn: Exception loading config: " + ex);
-                Config = new CarryOnConfig(CurrentConfigVersion);
+                config = new CarryOnConfig(CurrentConfigVersion);
             }
 
             var worldConfig = coreApi.World?.Config;
             if (worldConfig == null)
             {
                 coreApi.Logger?.Error("CarryOn: Unable to access world config. CarryOn features may not work correctly.");
-                return;
+                return config;
             }
 
             // Cleanup old world config: Remove all keys starting with "carryon:"
@@ -62,7 +61,8 @@ namespace CarryOn.Server.Logic
             }
 
             // Sync to world config so JSON patching and clients can access values
-            worldConfig.GetOrAddTreeAttribute(ModId).MergeTree(Config.ToTreeAttribute());
+            worldConfig.GetOrAddTreeAttribute(ModId).MergeTree(config.ToTreeAttribute());
+            return config;
         }
     }
 }

--- a/src/Utility/CarryRotationHelper.cs
+++ b/src/Utility/CarryRotationHelper.cs
@@ -1,0 +1,298 @@
+using System;
+using CarryOn.API.Common.Models;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+
+namespace CarryOn.Utility
+{
+    public static class CarryRotationHelper
+    {
+        private const float TwoPi = (float)(2 * Math.PI);
+        private const float HalfPi = (float)(Math.PI / 2);
+
+        private static readonly float AngleNorth = 0f;
+        private static readonly float AngleEast = HalfPi;
+        private static readonly float AngleSouth = (float)Math.PI;
+        private static readonly float AngleWest = (float)(3 * Math.PI / 2);
+
+        private static readonly BlockFacing[] NorthWestSouthEast = [BlockFacing.NORTH, BlockFacing.WEST, BlockFacing.SOUTH, BlockFacing.EAST];
+        private static readonly BlockFacing[] NorthEastSouthWest = [BlockFacing.NORTH, BlockFacing.EAST, BlockFacing.SOUTH, BlockFacing.WEST];
+
+        private static readonly BlockFacing[] MeshAngleFacing = [BlockFacing.SOUTH, BlockFacing.WEST, BlockFacing.NORTH, BlockFacing.EAST];
+
+        private const float CardinalEpsilon = 0.001f;
+
+        public static float NormalizeAngle(float angle)
+        {
+            angle %= TwoPi;
+            if (angle < 0) angle += TwoPi;
+            return angle;
+        }
+
+        public static int NormalizeSteps(int steps)
+        {
+            return ((steps % 4) + 4) % 4;
+        }
+
+        public static float GetMeshAngle(BlockFacing facing)
+        {
+            switch (facing.Code)
+            {
+                case "north": return AngleNorth;
+                case "east": return AngleEast;
+                case "south": return AngleSouth;
+                case "west": return AngleWest;
+                default: return AngleNorth;
+            }
+        }
+
+        public static BlockFacing? GetBlockFacing(Block block)
+        {
+            if (block?.Code?.Path == null) return null;
+            return GetBlockFacing(block.Code);
+        }
+
+        public static BlockFacing? GetBlockFacing(AssetLocation code)
+        {
+            if (code?.Path == null) return null;
+            var parts = code.Path.Split('-');
+            return parts.Length > 0 ? BlockFacing.FromCode(parts[parts.Length - 1]) : null;
+        }
+
+        public static BlockPos RotateOffset(BlockPos offset, int steps)
+        {
+            steps = NormalizeSteps(steps);
+            if (steps == 0) return offset.Copy();
+            int x = offset.X, z = offset.Z;
+            return steps switch
+            {
+                1 => new BlockPos(z, offset.Y, -x),
+                2 => new BlockPos(-x, offset.Y, -z),
+                3 => new BlockPos(-z, offset.Y, x),
+                _ => offset.Copy()
+            };
+        }
+
+        public static BlockFacing RotateFacing(BlockFacing facing, int steps)
+        {
+            int idx = Array.IndexOf(NorthWestSouthEast, facing);
+            if (idx < 0) return facing;
+            steps = NormalizeSteps(steps);
+            return NorthWestSouthEast[(idx + steps) % 4];
+        }
+
+        public static Block? GetWallSignForFacing(IWorldAccessor world, AssetLocation originalCode, BlockFacing newFacing)
+        {
+            return GetRotatedVariantBlock(world, originalCode, newFacing);
+        }
+
+        public static Block? GetRotatedVariantBlock(IWorldAccessor world, AssetLocation originalCode, BlockFacing rotatedFacing)
+        {
+            var parts = originalCode.Path.Split('-');
+            if (parts.Length < 2) return null;
+            var basePath = string.Join("-", parts, 0, parts.Length - 1);
+            var newCode = new AssetLocation(originalCode.Domain, $"{basePath}-{rotatedFacing.Code}");
+            return world.GetBlock(newCode);
+        }
+
+        public static int GetActualRotationSteps(CarriedBlock carriedBlock, IWorldAccessor world, BlockPos parentPos)
+        {
+            var originalMeshAngle = carriedBlock.OriginalMeshAngle;
+            if (originalMeshAngle.HasValue)
+            {
+                var placedBE = world.BlockAccessor.GetBlockEntity(parentPos);
+                if (placedBE != null)
+                {
+                    var tempAttr = new TreeAttribute();
+                    placedBE.ToTreeAttributes(tempAttr);
+                    if (tempAttr.HasAttribute("meshAngle"))
+                    {
+                        var placedMeshAngle = tempAttr.GetFloat("meshAngle");
+                        var delta = NormalizeAngle(placedMeshAngle - originalMeshAngle.Value);
+                        var rawSteps = delta / HalfPi;
+                        var steps = (int)Math.Round(rawSteps);
+                        return NormalizeSteps(steps);
+                    }
+                }
+            }
+
+            var originalCode = carriedBlock.OriginalBlockCode;
+            if (originalCode != null)
+            {
+                var originalFacing = GetBlockFacing(originalCode);
+                if (originalFacing != null)
+                {
+                    var placedBlock = world.BlockAccessor.GetBlock(parentPos);
+                    var placedFacing = GetBlockFacing(placedBlock);
+                    if (placedFacing != null)
+                    {
+                        int fromIdx = Array.IndexOf(NorthEastSouthWest, originalFacing);
+                        int toIdx = Array.IndexOf(NorthEastSouthWest, placedFacing);
+                        if (fromIdx >= 0 && toIdx >= 0)
+                            return NormalizeSteps(toIdx - fromIdx);
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        public static int EstimatePreflightRotation(CarriedBlock carriedBlock, Entity entity, BlockSelection selection, bool dropped)
+        {
+            if (!carriedBlock.OriginalMeshAngle.HasValue) return 0;
+
+            float placedMeshAngle;
+            if (dropped)
+            {
+                var meshFacing = selection.Face;
+                if (meshFacing == null || meshFacing.IsVertical) return 0;
+                placedMeshAngle = -GetMeshAngle(meshFacing);
+            }
+            else
+            {
+                var yaw = NormalizeAngle((float)entity.Pos.Yaw);
+                placedMeshAngle = (float)((yaw + Math.PI) % TwoPi);
+            }
+
+            var originalAngle = carriedBlock.OriginalMeshAngle.Value;
+            var delta = NormalizeAngle(placedMeshAngle - originalAngle);
+            var steps = (int)Math.Round(delta / HalfPi);
+            return NormalizeSteps(steps);
+        }
+
+        public static int GetBaseFacingRotationSteps(CarriedBlock carriedBlock)
+        {
+            var originalFacing = GetOriginalFacing(carriedBlock);
+            var baseFacing = GetBaseFacing(carriedBlock);
+
+            if (originalFacing == null || baseFacing == null)
+                return 0;
+
+            int fromIdx = Array.IndexOf(NorthEastSouthWest, originalFacing);
+            int toIdx = Array.IndexOf(NorthEastSouthWest, baseFacing);
+
+            if (fromIdx < 0 || toIdx < 0)
+                return 0;
+
+            return NormalizeSteps(toIdx - fromIdx);
+        }
+
+        public static BlockFacing? GetOriginalFacing(CarriedBlock carriedBlock)
+        {
+            if (carriedBlock.OriginalMeshAngle.HasValue)
+            {
+                var angle = NormalizeAngle(carriedBlock.OriginalMeshAngle.Value);
+                foreach (var facing in NorthEastSouthWest)
+                {
+                    if (Math.Abs(angle - GetMeshAngle(facing)) < CardinalEpsilon)
+                        return facing;
+                }
+            }
+
+            if (carriedBlock.OriginalBlockCode != null)
+                return GetBlockFacing(carriedBlock.OriginalBlockCode);
+
+            return GetBlockFacing(carriedBlock.Block);
+        }
+
+        public static BlockFacing? GetBaseFacing(CarriedBlock carriedBlock)
+        {
+            var baseFacing = GetBlockFacing(carriedBlock.Block);
+            return baseFacing ?? BlockFacing.NORTH;
+        }
+
+        public static int GetOriginalToModelDefaultSteps(CarriedBlock carriedBlock, string? modelDefaultFacing = "east")
+        {
+            var defaultIdx = ModelDefaultFacingToSteps(modelDefaultFacing);
+
+            if (carriedBlock.OriginalMeshAngle.HasValue)
+            {
+                var angle = NormalizeAngle(carriedBlock.OriginalMeshAngle.Value);
+                var meshAngleStep = (int)Math.Round(angle / HalfPi) % 4;
+                if (meshAngleStep >= 0 && meshAngleStep < MeshAngleFacing.Length)
+                {
+                    var originalFacing = MeshAngleFacing[meshAngleStep];
+                    int originalIdx = Array.IndexOf(NorthWestSouthEast, originalFacing);
+                    if (originalIdx >= 0)
+                        return NormalizeSteps(originalIdx - defaultIdx);
+                }
+            }
+
+            if (carriedBlock.OriginalBlockCode != null)
+            {
+                var originalFacing = GetBlockFacing(carriedBlock.OriginalBlockCode);
+                if (originalFacing != null)
+                {
+                    int originalIdx = Array.IndexOf(NorthWestSouthEast, originalFacing);
+                    if (originalIdx >= 0)
+                        return NormalizeSteps(originalIdx - defaultIdx);
+                }
+            }
+
+            var baseFacing = GetBlockFacing(carriedBlock.Block);
+            if (baseFacing != null)
+            {
+                int baseIdx = Array.IndexOf(NorthWestSouthEast, baseFacing);
+                if (baseIdx >= 0)
+                    return NormalizeSteps(baseIdx - defaultIdx);
+            }
+
+            return 0;
+        }
+
+        private static int ModelDefaultFacingToSteps(string? facing)
+        {
+            return facing?.ToLowerInvariant() switch
+            {
+                "north" => 0,
+                "west" => 1,
+                "south" => 2,
+                "east" => 3,
+                _ => 3
+            };
+        }
+
+        public static float FacingToYRotationDegrees(BlockFacing facing)
+        {
+            return facing.Code switch
+            {
+                "north" => 0f,
+                "east" => 90f,
+                "south" => 180f,
+                "west" => 270f,
+                _ => 0f
+            };
+        }
+
+        public static Block? ResolveRenderBlock(IWorldAccessor world, CarriedBlock carriedBlock, string? rootRenderVariant, string? rootRenderFacing)
+        {
+            if (string.IsNullOrEmpty(rootRenderVariant))
+                return null;
+
+            var code = carriedBlock.OriginalBlockCode ?? carriedBlock.Block.Code;
+            var path = code.Path;
+            var parts = path.Split('-');
+
+            if (parts.Length < 2) return null;
+
+            var facing = string.IsNullOrEmpty(rootRenderFacing) ? "east" : rootRenderFacing;
+
+            string newPath;
+            if (parts.Length == 2)
+            {
+                newPath = $"{parts[0]}-{rootRenderVariant}-{facing}";
+            }
+            else
+            {
+                var basePath = string.Join("-", parts, 0, parts.Length - 2);
+                newPath = $"{basePath}-{rootRenderVariant}-{facing}";
+            }
+
+            var newCode = new AssetLocation(code.Domain, newPath);
+            var resolved = world.GetBlock(newCode);
+            return resolved?.Id != 0 ? resolved : null;
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors how configuration (`CarryOnConfig`) is accessed and distributed throughout the CarryOn mod, moving from pushing config copies to consumers toward a centralized, live-access model. Now, all consumers read the config directly via the `IConfigProvider` interface, eliminating the need for per-instance config copies and update methods. The initialization and hot-reload flows are clarified and improved, and detailed technical documentation is added to explain the new architecture.

**Config Access and Distribution Refactor:**

- All config consumers now access `CarryOnConfig` through the `IConfigProvider` interface, using a runtime cast from `ICarryManager`, rather than storing private copies or receiving updates via `UpdateConfig()` methods. (`CarryRenderCacheManager`, `CarryRenderDispatcher`, `CarryHandler`, `EntityCarryRenderer`) [[1]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fL19-R35) [[2]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fL208-R206) [[3]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548L21-L43) [[4]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548L159-R155) [[5]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L141-R145) [[6]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L231-R234) [[7]](diffhunk://#diff-cbe71c19d206399216b97e7b592da88627aab9358597917b36ce830fc36127d3L13)

- The `UpdateConfig()` methods and private config fields are removed from renderers and handlers, replaced with live property access via the `IConfigProvider` pattern. [[1]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fL19-R35) [[2]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548L21-L43) [[3]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L156-R160) [[4]](diffhunk://#diff-cbe71c19d206399216b97e7b592da88627aab9358597917b36ce830fc36127d3L13)

**Initialization and Startup Improvements:**

- The config initialization sequence in `CarrySystem.StartPre` is rewritten: the server loads config from disk and syncs to the world config tree; the client loads from the synced tree. This avoids redundant deserialization and ensures a single source of truth. [[1]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750L88-R101) [[2]](diffhunk://#diff-42833278cb35cef3819b4d9af09c8c671512d91e69114facf59cc3c080be1750R111)

- The wiring of config change handlers is simplified: rather than pushing new configs to each consumer, only necessary cache invalidations or refreshes are triggered.

**Documentation:**

- A comprehensive technical overview is added (`docs/technical-overview/config-initialization-and-flow.md`), detailing the config initialization, distribution, consumer access patterns, hot-reload mechanisms, and key design decisions.

**Codebase Cleanup:**

- Unused config parameters and unnecessary usings are removed from renderer constructors and files. [[1]](diffhunk://#diff-cbe71c19d206399216b97e7b592da88627aab9358597917b36ce830fc36127d3L4) [[2]](diffhunk://#diff-cbe71c19d206399216b97e7b592da88627aab9358597917b36ce830fc36127d3L13) [[3]](diffhunk://#diff-ba78ab62fcbb90e26d03b3ca15db39a794ab1ceb80b208bba76768708329934fR7) [[4]](diffhunk://#diff-abcace7adf4f63c74384fe00df240fc4b562df7e06bc2bbb690b58f1241ea548R7)

**Summary:**  
This refactor centralizes config management, reduces code duplication, and makes hot-reloading and live config access robust and maintainable, with clear documentation of the improved architecture.